### PR TITLE
init: structure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*.proto]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[*.yaml]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[*.go]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  STORE_PATH: ""
+
+jobs:
+  build-test:
+    name: Build Test
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+          cache: true
+
+      - name: Test Build
+        run: go build ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.4.0
+        with:
+          # Optional: golangci-lint command line arguments.
+          args: "--timeout=10m"
+
+  unittest:
+    name: Unit Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+          cache: true
+
+      - name: Unit tests
+        run: |
+          go test ./... -coverprofile=coverage.out -covermode=atomic -p=1
+          go tool cover -func coverage.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,69 @@
+run:
+  allow-parallel-runners: true
+
+issues:
+  exclude:
+    - "if statements should only be cuddled with assignments" # from wsl
+    - "if statements should only be cuddled with assignments used in the if statement itself" # from wsl
+    - "assignments should only be cuddled with other assignments" # from wsl. false positive case: var a bool\nb := true
+    - "declarations should never be cuddled" # from wsl
+  # don't skip warning about doc comments
+  # don't exclude the default set of lint
+  exclude-use-default: false
+  # restore some of the defaults
+  # (fill in the rest as needed)
+  exclude-rules:
+    - path: internal/*
+      linters:
+        - dupl
+
+linters-settings:
+  wsl:
+    allow-assign-and-call: false
+    strict-append: false
+  revive:
+    rules:
+      - name: blank-imports
+        disabled: true
+
+linters:
+  disable-all: true
+  enable:
+    - dupl
+    - errcheck
+    - exportloopref
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    # - lll
+    - misspell
+    - nakedret
+    - prealloc
+    - staticcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - containedctx
+    - durationcheck
+    - errname
+    - exhaustive
+    - forcetypeassert
+    - goheader
+    - goprintffuncname
+    # - gosec
+    - musttag
+    - nestif
+    - nolintlint
+    - nosprintfhostport
+    - predeclared
+    - reassign
+    - revive
+    - tenv
+    - testableexamples
+    - whitespace
+    - wsl

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,32 @@
+{
+    "go.useLanguageServer": true,
+    "go.lintOnSave": "package",
+    "go.vetOnSave": "workspace",
+    "go.coverOnSave": false,
+    "go.lintTool": "golangci-lint",
+    "go.lintFlags": [
+        "--config=${workspaceFolder}/.golangci.yml",
+    ],
+    "go.inferGopath": true,
+    "go.alternateTools": {},
+    "go.coverOnSingleTest": true,
+    "go.testTimeout": "900s",
+    "go.testFlags": [
+        "-v",
+        "-count=1"
+    ],
+    "go.toolsManagement.autoUpdate": true,
+    "go.coverOnSingleTestFile": true,
+    "gopls": {
+        "build.buildFlags": [],
+        "ui.completion.usePlaceholders": true,
+        "ui.semanticTokens": true
+    },
+    "[go]": {
+        "editor.insertSpaces": false,
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "always"
+        },
+    },
+}

--- a/cmd/unspeech/main.go
+++ b/cmd/unspeech/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,45 @@
+version: "0.2"
+ignorePaths: []
+dictionaryDefinitions: []
+dictionaries: []
+words:
+  - dupl
+  - errcheck
+  - exportloopref
+  - goconst
+  - gocyclo
+  - gofmt
+  - goimports
+  - gosimple
+  - govet
+  - ineffassign
+  - lll
+  - misspell
+  - nakedret
+  - prealloc
+  - staticcheck
+  - typecheck
+  - unconvert
+  - unparam
+  - unused
+  - containedctx
+  - durationcheck
+  - errname
+  - exhaustive
+  - forcetypeassert
+  - goheader
+  - goprintffuncname
+  - gosec
+  - musttag
+  - nestif
+  - nolintlint
+  - nosprintfhostport
+  - predeclared
+  - reassign
+  - revive
+  - tenv
+  - testableexamples
+  - whitespace
+  - wsl
+ignoreWords: []
+import: []

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/moeru-ai/unspeech
+
+go 1.23.2


### PR DESCRIPTION
## Golang project init

```shell
go mod init github.com/moeru-ai/unspeech
go mod tidy
```

## `.editorconfig` init

Basic config for `.proto`, `.yaml`, and `.go` files.

## `.golangci-lint.yaml` init

Enabled linters all by default, and disabled many bad ones.

## `cSpell.config.yaml` init

Added unknown names.

## `.vscode/settings.json`

General and best practice of Golang VSCode config.