### PR TITLE
fix: OpenAI speech handler endpoint & errors

### DIFF
--- a/pkg/backend/openai/speech.go
+++ b/pkg/backend/openai/speech.go
@@ -16,12 +16,15 @@ import (
 )
 
 func HandleSpeech(c echo.Context, options mo.Option[types.SpeechRequestOptions]) mo.Result[any] {
+	// Extract options safely once
+	opt := options.MustGet()
+
 	values := types.OpenAISpeechRequestOptions{
-		Model:          options.MustGet().Model,
-		Input:          options.MustGet().Input,
-		Voice:          options.MustGet().Voice,
-		ResponseFormat: options.MustGet().ResponseFormat,
-		Speed:          options.MustGet().Speed,
+		Model:          opt.Model,
+		Input:          opt.Input,
+		Voice:          opt.Voice,
+		ResponseFormat: opt.ResponseFormat,
+		Speed:          opt.Speed,
 	}
 
 	payload := lo.Must(json.Marshal(values))
@@ -29,42 +32,53 @@ func HandleSpeech(c echo.Context, options mo.Option[types.SpeechRequestOptions])
 	req, err := http.NewRequestWithContext(
 		c.Request().Context(),
 		http.MethodPost,
-		"https://openai.com/v1/audio/speech",
+		"https://api.openai.com/v1/audio/speech",
 		bytes.NewBuffer(payload),
 	)
 	if err != nil {
 		return mo.Err[any](apierrors.NewErrInternal().WithCaller())
 	}
 
-	// Proxy the Authorization header
 	req.Header.Set("Authorization", c.Request().Header.Get("Authorization"))
 	req.Header.Set("Content-Type", "application/json")
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return mo.Err[any](apierrors.NewErrBadGateway().WithDetail(err.Error()).WithError(err).WithCaller())
+		return mo.Err[any](
+			apierrors.NewErrBadGateway().
+				WithDetail(err.Error()).
+				WithError(err).
+				WithCaller(),
+		)
 	}
-
 	defer func() { _ = res.Body.Close() }()
 
-	if res.StatusCode >= 400 && res.StatusCode < 600 {
+	if res.StatusCode >= 400 {
+		ct := res.Header.Get("Content-Type")
 		switch {
-		case strings.HasPrefix(res.Header.Get("Content-Type"), "application/json"):
-			return mo.Err[any](apierrors.
-				NewUpstreamError(res.StatusCode).
-				WithDetail(utils.NewJSONResponseError(res.StatusCode, res.Body).OrEmpty().Error()))
-		case strings.HasPrefix(res.Header.Get("Content-Type"), "text/"):
-			return mo.Err[any](apierrors.
-				NewUpstreamError(res.StatusCode).
-				WithDetail(utils.NewTextResponseError(res.StatusCode, res.Body).OrEmpty().Error()))
+		case strings.HasPrefix(ct, "application/json"):
+			return mo.Err[any](
+				apierrors.NewUpstreamError(res.StatusCode).
+					WithDetail(utils.NewJSONResponseError(res.StatusCode, res.Body).OrEmpty().Error()),
+			)
+		case strings.HasPrefix(ct, "text/"):
+			return mo.Err[any](
+				apierrors.NewUpstreamError(res.StatusCode).
+					WithDetail(utils.NewTextResponseError(res.StatusCode, res.Body).OrEmpty().Error()),
+			)
 		default:
-			slog.Warn("unknown upstream error with unknown Content-Type",
+			slog.Warn("unknown upstream error",
 				slog.Int("status", res.StatusCode),
-				slog.String("content_type", res.Header.Get("Content-Type")),
+				slog.String("content_type", ct),
 				slog.String("content_length", res.Header.Get("Content-Length")),
+			)
+			return mo.Err[any](
+				apierrors.NewUpstreamError(res.StatusCode).
+					WithDetail("unknown Content-Type: " + ct),
 			)
 		}
 	}
 
-	return mo.Ok[any](c.Stream(http.StatusOK, "audio/mp3", res.Body))
+	// Stream audio response with correct upstream content type
+	return mo.Ok[any](c.Stream(http.StatusOK, res.Header.Get("Content-Type"), res.Body))
 }


### PR DESCRIPTION
### **Summary:**
Fixes and refines the HandleSpeech implementation for the OpenAI speech API.

### **Overall updates:**
- Corrected API of OpenAI endpoint to `https://api.openai.com/v1/audio/speech.`
- Extracted options.MustGet() once to avoid repeated panics.
- Improved error handling for JSON, text, and unknown upstream responses.
- Forwarded upstream Content-Type instead of forcing audio/mp3.
- Added clearer logging for unknown upstream errors.

### **Explaination:**
- Prevents runtime panics from multiple MustGet() calls.
- Ensures correct audio format streaming (mp3, wav, ogg, etc.).
- Provides more accurate error reporting and observability.
