### PR TITLE
fix: better wss handshake error handling for alibaba

### DIFF
--- a/pkg/backend/alibaba/speech.go
+++ b/pkg/backend/alibaba/speech.go
@@ -137,15 +137,26 @@ func HandleSpeech(c echo.Context, options mo.Option[types.SpeechRequestOptions])
 
 	conn, resp, err := websocket.DefaultDialer.Dial("wss://dashscope.aliyuncs.com/api-ws/v1/inference", headers)
 	if err != nil {
-		defer resp.Body.Close()
-		jsonErrResult := utils.NewJSONResponseError(resp.StatusCode, resp.Body)
-		jsonErr, parseErr := jsonErrResult.Get()
-		if parseErr == nil {
-			return mo.Err[any](apierrors.NewErrInternal().WithDetail(jsonErr.Error()).WithCaller())
-		} else {
-			// Pass upstream error, local error (wss badhandshake) is not helpful
-			return mo.Err[any](apierrors.NewUpstreamError(resp.StatusCode).WithDetail(parseErr.Error()).WithCaller())
+		if resp == nil {
+			return mo.Err[any](apierrors.NewErrBadGateway().WithDetail(err.Error()).WithCaller())
 		}
+
+		defer resp.Body.Close()
+
+		upstreamErrResult := utils.NewJSONResponseError(resp.StatusCode, resp.Body)
+		jsonErr, upstreamErr := upstreamErrResult.Get()
+
+		var detail string
+
+		if upstreamErr == nil {
+			detail = jsonErr.Error()
+		} else {
+			// The error from parsing the response is more specific than the generic handshake error.
+			detail = upstreamErr.Error()
+		}
+
+		// Pass upstream error, local error (wss badhandshake) is not helpful
+		return mo.Err[any](apierrors.NewUpstreamError(resp.StatusCode).WithDetail(detail).WithCaller())
 	}
 
 	defer func() {

--- a/pkg/backend/alibaba/speech.go
+++ b/pkg/backend/alibaba/speech.go
@@ -137,7 +137,14 @@ func HandleSpeech(c echo.Context, options mo.Option[types.SpeechRequestOptions])
 
 	conn, resp, err := websocket.DefaultDialer.Dial("wss://dashscope.aliyuncs.com/api-ws/v1/inference", headers)
 	if err != nil {
-		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
+		// We'd get HTTP Response if the wss handshake fails e.g. invalid apikey
+		if resp != nil {
+			detail := utils.NewJSONResponseError(resp.StatusCode, resp.Body).OrEmpty().Error()
+			// Pass upstream error, local error (wss badhandshake) is not helpful
+			return mo.Err[any](apierrors.NewUpstreamError(resp.StatusCode).WithDetail(detail).WithCaller())
+		}
+		// If no response, it's a network/connection error
+		return mo.Err[any](apierrors.NewErrBadGateway().WithDetail(err.Error()).WithError(err).WithCaller())
 	}
 
 	defer func() {


### PR DESCRIPTION
# The problem:
Bad auth causes wss handshake to fail, which results in a confusing 500 error shown to the user.

<img src="https://media.discordapp.net/attachments/1407646249120694405/1457653454603419780/image.png?ex=695cc911&is=695b7791&hm=f71f99781d2b2d339f9af5e3ef8e4818a95830baca695ee5029b726619d84146&=&format=webp&quality=lossless&width=1376&height=765"/>

# The fix:

Pass upstream error correctly