### PR TITLE
feat: add MiniMax TTS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ unSpeech lets you use various online TTS with OpenAI-compatible API.
 - [Alibaba Cloud Model Studio / 阿里云百炼 / CosyVoice](https://www.alibabacloud.com/en/product/modelstudio)
 - [Volcano Engine / 火山引擎语音技术](https://www.volcengine.com/product/voice-tech)
 - [ElevenLabs](https://elevenlabs.io/docs/api-reference/text-to-speech/convert)
+- [MiniMax](https://platform.minimaxi.com/docs/guides/speech-t2a-http)
 - [Koemotion (by Rinna)](https://koemotion.rinna.co.jp/)
 
 ## Getting Started

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moeru-ai/unspeech/pkg/backend/elevenlabs"
 	"github.com/moeru-ai/unspeech/pkg/backend/koemotion"
 	"github.com/moeru-ai/unspeech/pkg/backend/microsoft"
+	"github.com/moeru-ai/unspeech/pkg/backend/minimax"
 	"github.com/moeru-ai/unspeech/pkg/backend/openai"
 	"github.com/moeru-ai/unspeech/pkg/backend/types"
 	"github.com/moeru-ai/unspeech/pkg/backend/volcengine"
@@ -37,6 +38,8 @@ func Speech(c echo.Context) mo.Result[any] {
 		return volcengine.HandleSpeech(c, utils.ResultToOption(options))
 	case "ali", "aliyun", "alibaba", "bailian", "alibaba-model-studio":
 		return alibaba.HandleSpeech(c, utils.ResultToOption(options))
+	case "minimax", "minimax-tts":
+		return minimax.HandleSpeech(c, utils.ResultToOption(options))
 	default:
 		return mo.Err[any](apierrors.NewErrBadRequest().WithDetail("unsupported backend"))
 	}
@@ -63,6 +66,8 @@ func Voices(c echo.Context) mo.Result[any] {
 		return volcengine.HandleVoices(c, utils.ResultToOption(options))
 	case "ali", "aliyun", "alibaba", "bailian", "alibaba-model-studio":
 		return alibaba.HandleVoices(c, utils.ResultToOption(options))
+	case "minimax", "minimax-tts":
+		return minimax.HandleVoices(c, utils.ResultToOption(options))
 	default:
 		return mo.Err[any](apierrors.NewErrBadRequest().WithDetail("unsupported backend"))
 	}

--- a/pkg/backend/minimax/speech.go
+++ b/pkg/backend/minimax/speech.go
@@ -1,0 +1,64 @@
+// Package minimax provides MiniMax TTS integration
+package minimax
+
+// VoiceSetting MiniMax 音色设置
+type VoiceSetting struct {
+	VoiceID           string  `json:"voice_id"`
+	Speed             float64 `json:"speed,omitempty"`
+	Vol               float64 `json:"vol,omitempty"`
+	Pitch             float64 `json:"pitch,omitempty"`
+	Emotion           string  `json:"emotion,omitempty"`
+	TextNormalization string  `json:"text_normalization,omitempty"`
+	LatexRead         string  `json:"latex_read,omitempty"`
+}
+
+// AudioSetting MiniMax 音频设置
+type AudioSetting struct {
+	SampleRate int    `json:"sample_rate,omitempty"`
+	Bitrate    int    `json:"bitrate,omitempty"`
+	Format     string `json:"format,omitempty"`
+	Channel    int    `json:"channel,omitempty"`
+}
+
+// TTSRequest MiniMax TTS 请求
+type TTSRequest struct {
+	Model        string        `json:"model"`
+	Text         string        `json:"text"`
+	Stream       bool          `json:"stream,omitempty"`
+	VoiceSetting *VoiceSetting `json:"voice_setting,omitempty"`
+	AudioSetting *AudioSetting `json:"audio_setting,omitempty"`
+	OutputFormat string        `json:"output_format,omitempty"`
+}
+
+// TTSResponseData MiniMax TTS 响应数据
+type TTSResponseData struct {
+	Audio        string `json:"audio"`
+	SubtitleFile string `json:"subtitle_file,omitempty"`
+	Status       int    `json:"status"`
+}
+
+// TTSResponseExtraInfo MiniMax TTS 响应额外信息
+type TTSResponseExtraInfo struct {
+	AudioLength     int    `json:"audio_length"`
+	AudioSampleRate int    `json:"audio_sample_rate"`
+	AudioSize       int    `json:"audio_size"`
+	Bitrate         int    `json:"bitrate"`
+	AudioFormat     string `json:"audio_format"`
+	AudioChannel    int    `json:"audio_channel"`
+	WordCount       int    `json:"word_count"`
+	UsageCharacters int    `json:"usage_characters"`
+}
+
+// TTSResponseBaseResp MiniMax TTS 响应基础信息
+type TTSResponseBaseResp struct {
+	StatusCode int    `json:"status_code"`
+	StatusMsg  string `json:"status_msg"`
+}
+
+// TTSResponse MiniMax TTS 响应
+type TTSResponse struct {
+	Data      TTSResponseData      `json:"data"`
+	TraceID   string              `json:"trace_id"`
+	ExtraInfo TTSResponseExtraInfo `json:"extra_info"`
+	BaseResp  TTSResponseBaseResp  `json:"base_resp"`
+}

--- a/pkg/backend/minimax/speech.go
+++ b/pkg/backend/minimax/speech.go
@@ -1,5 +1,20 @@
-// Package minimax provides MiniMax TTS integration
 package minimax
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/moeru-ai/unspeech/pkg/apierrors"
+	"github.com/moeru-ai/unspeech/pkg/backend/types"
+	"github.com/moeru-ai/unspeech/pkg/utils"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+)
 
 // VoiceSetting MiniMax 音色设置
 type VoiceSetting struct {
@@ -61,4 +76,334 @@ type TTSResponse struct {
 	TraceID   string              `json:"trace_id"`
 	ExtraInfo TTSResponseExtraInfo `json:"extra_info"`
 	BaseResp  TTSResponseBaseResp  `json:"base_resp"`
+}
+
+// HandleSpeech 处理 MiniMax TTS 请求
+func HandleSpeech(c echo.Context, options mo.Option[types.SpeechRequestOptions]) mo.Result[any] {
+	opts := options.MustGet()
+
+	// 获取 token
+	token := strings.TrimPrefix(c.Request().Header.Get("Authorization"), "Bearer ")
+
+	// 从 ExtraBody 获取 stream 参数
+	stream := utils.GetByJSONPath[bool](opts.ExtraBody, "{ .stream }")
+
+	// 如果是流式请求，使用流式处理
+	if stream {
+		return handleStreamingSpeech(c, token, opts)
+	}
+
+	// 构建 MiniMax 请求
+	reqBody := TTSRequest{
+		Model:        opts.Model,
+		Text:         opts.Input,
+		Stream:       false,
+		OutputFormat: "hex",
+	}
+
+	// 设置 voice_id（从用户传入的 voice 字段）
+	voiceID := opts.Voice
+	if voiceID != "" {
+		reqBody.VoiceSetting = &VoiceSetting{
+			VoiceID: voiceID,
+		}
+	}
+
+	// 从 ExtraBody 获取其他参数
+	if speed := utils.GetByJSONPath[*float64](opts.ExtraBody, "{ .speed }"); speed != nil {
+		if reqBody.VoiceSetting == nil {
+			reqBody.VoiceSetting = &VoiceSetting{}
+		}
+		reqBody.VoiceSetting.Speed = *speed
+	}
+
+	if vol := utils.GetByJSONPath[*float64](opts.ExtraBody, "{ .vol }"); vol != nil {
+		if reqBody.VoiceSetting == nil {
+			reqBody.VoiceSetting = &VoiceSetting{}
+		}
+		reqBody.VoiceSetting.Vol = *vol
+	}
+
+	if pitch := utils.GetByJSONPath[*float64](opts.ExtraBody, "{ .pitch }"); pitch != nil {
+		if reqBody.VoiceSetting == nil {
+			reqBody.VoiceSetting = &VoiceSetting{}
+		}
+		reqBody.VoiceSetting.Pitch = *pitch
+	}
+
+	if emotion := utils.GetByJSONPath[*string](opts.ExtraBody, "{ .emotion }"); emotion != nil {
+		if reqBody.VoiceSetting == nil {
+			reqBody.VoiceSetting = &VoiceSetting{}
+		}
+		reqBody.VoiceSetting.Emotion = *emotion
+	}
+
+	// 音频设置
+	if sampleRate := utils.GetByJSONPath[*int](opts.ExtraBody, "{ .sample_rate }"); sampleRate != nil {
+		reqBody.AudioSetting = &AudioSetting{}
+		reqBody.AudioSetting.SampleRate = *sampleRate
+	}
+
+	if bitrate := utils.GetByJSONPath[*int](opts.ExtraBody, "{ .bitrate }"); bitrate != nil {
+		if reqBody.AudioSetting == nil {
+			reqBody.AudioSetting = &AudioSetting{}
+		}
+		reqBody.AudioSetting.Bitrate = *bitrate
+	}
+
+	if format := utils.GetByJSONPath[*string](opts.ExtraBody, "{ .format }"); format != nil {
+		if reqBody.AudioSetting == nil {
+			reqBody.AudioSetting = &AudioSetting{}
+		}
+		reqBody.AudioSetting.Format = *format
+	}
+
+	// 序列化请求体
+	jsonBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
+	}
+
+	// 创建请求
+	req, err := http.NewRequestWithContext(
+		c.Request().Context(),
+		http.MethodPost,
+		"https://api.minimaxi.com/v1/t2a_v2",
+		bytes.NewBuffer(jsonBytes),
+	)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
+	}
+
+	// 设置请求头
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	// 发送请求
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrBadGateway().WithDetail(err.Error()).WithError(err).WithCaller())
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	// 检查 HTTP 状态码
+	if resp.StatusCode >= 400 && resp.StatusCode < 600 {
+		switch {
+		case strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json"):
+			return mo.Err[any](apierrors.
+				NewUpstreamError(resp.StatusCode).
+				WithDetail(utils.NewJSONResponseError(resp.StatusCode, resp.Body).OrEmpty().Error()))
+		case strings.HasPrefix(resp.Header.Get("Content-Type"), "text/"):
+			return mo.Err[any](apierrors.
+				NewUpstreamError(resp.StatusCode).
+				WithDetail(utils.NewTextResponseError(resp.StatusCode, resp.Body).OrEmpty().Error()))
+		default:
+			slog.Warn("unknown upstream error with unknown Content-Type",
+				slog.Int("status", resp.StatusCode),
+				slog.String("content_type", resp.Header.Get("Content-Type")),
+			)
+		}
+	}
+
+	// 解析响应
+	var ttsResp TTSResponse
+	err = json.NewDecoder(resp.Body).Decode(&ttsResp)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrBadGateway().WithDetail(err.Error()).WithError(err).WithCaller())
+	}
+
+	// 检查业务状态码
+	if ttsResp.BaseResp.StatusCode != 0 {
+		return mo.Err[any](handleMinimaxError(ttsResp.BaseResp.StatusCode, ttsResp.BaseResp.StatusMsg))
+	}
+
+	// 解码 hex 音频
+	audioBytes, err := hex.DecodeString(ttsResp.Data.Audio)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail("failed to decode hex audio: "+err.Error()).WithError(err).WithCaller())
+	}
+
+	// 确定 Content-Type
+	contentType := "audio/mp3"
+	if reqBody.AudioSetting != nil && reqBody.AudioSetting.Format != "" {
+		contentType = lo.Ternary(reqBody.AudioSetting.Format == "pcm", "audio/pcm",
+			lo.Ternary(reqBody.AudioSetting.Format == "wav", "audio/wav",
+				lo.Ternary(reqBody.AudioSetting.Format == "flac", "audio/flac", "audio/mp3")))
+	}
+
+	return mo.Ok[any](c.Blob(http.StatusOK, contentType, audioBytes))
+}
+
+// handleMinimaxError 处理 MiniMax 错误码
+func handleMinimaxError(code int, msg string) *apierrors.Error {
+	var httpStatus int
+	switch code {
+	case 1004: // 鉴权失败
+		httpStatus = http.StatusUnauthorized
+	case 1002, 1039: // 限流
+		httpStatus = http.StatusTooManyRequests
+	case 1042, 2013: // 参数错误
+		httpStatus = http.StatusBadRequest
+	case 1001: // 超时
+		httpStatus = http.StatusGatewayTimeout
+	default:
+		httpStatus = http.StatusBadGateway
+	}
+	return apierrors.NewUpstreamError(httpStatus).WithDetailf("minimax error: %d - %s", code, msg)
+}
+
+// handleStreamingSpeech 处理流式 TTS 请求
+func handleStreamingSpeech(c echo.Context, token string, opts types.SpeechRequestOptions) mo.Result[any] {
+	// 构建 MiniMax 请求
+	reqBody := TTSRequest{
+		Model:        opts.Model,
+		Text:         opts.Input,
+		Stream:       true,
+		OutputFormat: "hex",
+	}
+
+	// 设置 voice_id
+	voiceID := opts.Voice
+	if voiceID != "" {
+		reqBody.VoiceSetting = &VoiceSetting{
+			VoiceID: voiceID,
+		}
+	}
+
+	// 从 ExtraBody 获取其他参数
+	if speed := utils.GetByJSONPath[*float64](opts.ExtraBody, "{ .speed }"); speed != nil {
+		if reqBody.VoiceSetting == nil {
+			reqBody.VoiceSetting = &VoiceSetting{}
+		}
+		reqBody.VoiceSetting.Speed = *speed
+	}
+
+	if vol := utils.GetByJSONPath[*float64](opts.ExtraBody, "{ .vol }"); vol != nil {
+		if reqBody.VoiceSetting == nil {
+			reqBody.VoiceSetting = &VoiceSetting{}
+		}
+		reqBody.VoiceSetting.Vol = *vol
+	}
+
+	if pitch := utils.GetByJSONPath[*float64](opts.ExtraBody, "{ .pitch }"); pitch != nil {
+		if reqBody.VoiceSetting == nil {
+			reqBody.VoiceSetting = &VoiceSetting{}
+		}
+		reqBody.VoiceSetting.Pitch = *pitch
+	}
+
+	if emotion := utils.GetByJSONPath[*string](opts.ExtraBody, "{ .emotion }"); emotion != nil {
+		if reqBody.VoiceSetting == nil {
+			reqBody.VoiceSetting = &VoiceSetting{}
+		}
+		reqBody.VoiceSetting.Emotion = *emotion
+	}
+
+	// 音频设置
+	if sampleRate := utils.GetByJSONPath[*int](opts.ExtraBody, "{ .sample_rate }"); sampleRate != nil {
+		reqBody.AudioSetting = &AudioSetting{}
+		reqBody.AudioSetting.SampleRate = *sampleRate
+	}
+
+	if bitrate := utils.GetByJSONPath[*int](opts.ExtraBody, "{ .bitrate }"); bitrate != nil {
+		if reqBody.AudioSetting == nil {
+			reqBody.AudioSetting = &AudioSetting{}
+		}
+		reqBody.AudioSetting.Bitrate = *bitrate
+	}
+
+	if format := utils.GetByJSONPath[*string](opts.ExtraBody, "{ .format }"); format != nil {
+		if reqBody.AudioSetting == nil {
+			reqBody.AudioSetting = &AudioSetting{}
+		}
+		reqBody.AudioSetting.Format = *format
+	}
+
+	// 序列化请求体
+	jsonBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
+	}
+
+	// 创建请求
+	req, err := http.NewRequestWithContext(
+		c.Request().Context(),
+		http.MethodPost,
+		"https://api.minimaxi.com/v1/t2a_v2",
+		bytes.NewBuffer(jsonBytes),
+	)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
+	}
+
+	// 设置请求头
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	// 发送请求
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrBadGateway().WithDetail(err.Error()).WithError(err).WithCaller())
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	// 检查 HTTP 状态码
+	if resp.StatusCode >= 400 && resp.StatusCode < 600 {
+		switch {
+		case strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json"):
+			return mo.Err[any](apierrors.
+				NewUpstreamError(resp.StatusCode).
+				WithDetail(utils.NewJSONResponseError(resp.StatusCode, resp.Body).OrEmpty().Error()))
+		default:
+			slog.Warn("unknown upstream error with unknown Content-Type",
+				slog.Int("status", resp.StatusCode),
+				slog.String("content_type", resp.Header.Get("Content-Type")),
+			)
+		}
+	}
+
+	// 流式处理：持续读取响应直到 status == 2
+	decoder := json.NewDecoder(resp.Body)
+	audioHex := new(strings.Builder)
+
+	for {
+		var ttsResp TTSResponse
+		if err := decoder.Decode(&ttsResp); err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			return mo.Err[any](apierrors.NewErrBadGateway().WithDetail(err.Error()).WithError(err).WithCaller())
+		}
+
+		// 检查业务状态码
+		if ttsResp.BaseResp.StatusCode != 0 {
+			return mo.Err[any](handleMinimaxError(ttsResp.BaseResp.StatusCode, ttsResp.BaseResp.StatusMsg))
+		}
+
+		// 追加音频数据
+		audioHex.WriteString(ttsResp.Data.Audio)
+
+		// status == 2 表示合成结束
+		if ttsResp.Data.Status == 2 {
+			break
+		}
+	}
+
+	// 解码 hex 音频
+	audioBytes, err := hex.DecodeString(audioHex.String())
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail("failed to decode hex audio: "+err.Error()).WithError(err).WithCaller())
+	}
+
+	// 确定 Content-Type
+	contentType := "audio/mp3"
+	if reqBody.AudioSetting != nil && reqBody.AudioSetting.Format != "" {
+		contentType = lo.Ternary(reqBody.AudioSetting.Format == "pcm", "audio/pcm",
+			lo.Ternary(reqBody.AudioSetting.Format == "wav", "audio/wav",
+				lo.Ternary(reqBody.AudioSetting.Format == "flac", "audio/flac", "audio/mp3")))
+	}
+
+	return mo.Ok[any](c.Blob(http.StatusOK, contentType, audioBytes))
 }

--- a/pkg/backend/minimax/voices.go
+++ b/pkg/backend/minimax/voices.go
@@ -1,0 +1,190 @@
+package minimax
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/moeru-ai/unspeech/pkg/apierrors"
+	"github.com/moeru-ai/unspeech/pkg/backend/types"
+	"github.com/moeru-ai/unspeech/pkg/utils"
+	"github.com/samber/mo"
+)
+
+// GetVoiceReq 获取音色列表请求
+type GetVoiceReq struct {
+	VoiceType string `json:"voice_type"`
+}
+
+// SystemVoice 系统音色
+type SystemVoice struct {
+	VoiceID     string   `json:"voice_id"`
+	VoiceName   string   `json:"voice_name"`
+	Description []string `json:"description"`
+}
+
+// VoiceCloning 快速复刻音色
+type VoiceCloning struct {
+	VoiceID     string   `json:"voice_id"`
+	Description []string `json:"description"`
+	CreatedTime string   `json:"created_time"`
+}
+
+// VoiceGeneration 文生音色
+type VoiceGeneration struct {
+	VoiceID     string   `json:"voice_id"`
+	Description []string `json:"description"`
+	CreatedTime string   `json:"created_time"`
+}
+
+// BaseResp 基础响应
+type BaseResp struct {
+	StatusCode int    `json:"status_code"`
+	StatusMsg  string `json:"status_msg"`
+}
+
+// GetVoiceResp 获取音色列表响应
+type GetVoiceResp struct {
+	SystemVoice      []SystemVoice     `json:"system_voice"`
+	VoiceCloning    []VoiceCloning   `json:"voice_cloning"`
+	VoiceGeneration []VoiceGeneration `json:"voice_generation"`
+	BaseResp        BaseResp          `json:"base_resp"`
+}
+
+var (
+	// 支持的音频格式
+	formats = []types.VoiceFormat{
+		{Name: "MP3", Extension: ".mp3", MimeType: "audio/mpeg"},
+		{Name: "PCM", Extension: ".pcm", MimeType: "audio/pcm"},
+		{Name: "FLAC", Extension: ".flac", MimeType: "audio/flac"},
+		{Name: "WAV", Extension: ".wav", MimeType: "audio/wav"},
+	}
+)
+
+// HandleVoices 处理获取音色列表请求
+func HandleVoices(c echo.Context, options mo.Option[types.VoicesRequestOptions]) mo.Result[any] {
+	// 获取 token
+	token := strings.TrimPrefix(c.Request().Header.Get("Authorization"), "Bearer ")
+
+	// 构建请求
+	reqBody := GetVoiceReq{
+		VoiceType: "all",
+	}
+
+	jsonBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
+	}
+
+	// 创建请求
+	req, err := http.NewRequestWithContext(
+		c.Request().Context(),
+		http.MethodPost,
+		"https://api.minimaxi.com/v1/get_voice",
+		strings.NewReader(string(jsonBytes)),
+	)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
+	}
+
+	// 设置请求头
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	// 发送请求
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrBadGateway().WithDetail(err.Error()).WithError(err).WithCaller())
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	// 检查 HTTP 状态码
+	if resp.StatusCode >= 400 && resp.StatusCode < 600 {
+		switch {
+		case strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json"):
+			return mo.Err[any](apierrors.
+				NewUpstreamError(resp.StatusCode).
+				WithDetail(utils.NewJSONResponseError(resp.StatusCode, resp.Body).OrEmpty().Error()))
+		default:
+			slog.Warn("unknown upstream error with unknown Content-Type",
+				slog.Int("status", resp.StatusCode),
+				slog.String("content_type", resp.Header.Get("Content-Type")),
+			)
+		}
+	}
+
+	// 解析响应
+	var voiceResp GetVoiceResp
+	err = json.NewDecoder(resp.Body).Decode(&voiceResp)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrBadGateway().WithDetail(err.Error()).WithError(err).WithCaller())
+	}
+
+	// 检查业务状态码
+	if voiceResp.BaseResp.StatusCode != 0 {
+		return mo.Err[any](handleMinimaxError(voiceResp.BaseResp.StatusCode, voiceResp.BaseResp.StatusMsg))
+	}
+
+	// 转换音色列表
+	voices := make([]types.Voice, 0, len(voiceResp.SystemVoice)+len(voiceResp.VoiceCloning)+len(voiceResp.VoiceGeneration))
+
+	// 添加系统音色
+	for _, v := range voiceResp.SystemVoice {
+		voices = append(voices, types.Voice{
+			ID:          v.VoiceID,
+			Name:        v.VoiceName,
+			Description: strings.Join(v.Description, ", "),
+			Labels: map[string]any{
+				"type": "system",
+			},
+			Tags:              []string{"system"},
+			Languages:         []types.VoiceLanguage{{Title: "Auto", Code: "auto"}},
+			Formats:           formats,
+			CompatibleModels:  []string{"speech-2.8-turbo", "speech-2.8-hd", "speech-2.6-turbo", "speech-2.6-hd"},
+			PredefinedOptions: map[string]any{},
+		})
+	}
+
+	// 添加快速复刻音色
+	for _, v := range voiceResp.VoiceCloning {
+		voices = append(voices, types.Voice{
+			ID:          v.VoiceID,
+			Name:        v.VoiceID,
+			Description: strings.Join(v.Description, ", "),
+			Labels: map[string]any{
+				"type":        "voice_cloning",
+				"createdTime": v.CreatedTime,
+			},
+			Tags:              []string{"voice_cloning"},
+			Languages:         []types.VoiceLanguage{{Title: "Auto", Code: "auto"}},
+			Formats:           formats,
+			CompatibleModels:  []string{"speech-2.8-turbo", "speech-2.8-hd"},
+			PredefinedOptions: map[string]any{},
+		})
+	}
+
+	// 添加文生音色
+	for _, v := range voiceResp.VoiceGeneration {
+		voices = append(voices, types.Voice{
+			ID:          v.VoiceID,
+			Name:        v.VoiceID,
+			Description: strings.Join(v.Description, ", "),
+			Labels: map[string]any{
+				"type":        "voice_generation",
+				"createdTime": v.CreatedTime,
+			},
+			Tags:              []string{"voice_generation"},
+			Languages:         []types.VoiceLanguage{{Title: "Auto", Code: "auto"}},
+			Formats:           formats,
+			CompatibleModels:  []string{"speech-2.8-turbo", "speech-2.8-hd"},
+			PredefinedOptions: map[string]any{},
+		})
+	}
+
+	return mo.Ok[any](types.ListVoicesResponse{
+		Voices: voices,
+	})
+}

--- a/pkg/backend/types/types.go
+++ b/pkg/backend/types/types.go
@@ -27,7 +27,7 @@ type OpenAISpeechRequestOptions struct {
 	// The speed of the generated audio.
 	// Select a value from 0.25 to 4.0.
 	// 1.0 is the default.
-	Speed int `json:"speed,omitempty"`
+	Speed float64 `json:"speed,omitempty"`
 
 	// Extension: allows you to add custom content to body.
 	ExtraBody map[string]any `json:"extra_body,omitempty"`

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -51,6 +51,7 @@ import {
   createUnAlibabaCloud,
   createUnElevenLabs,
   createUnMicrosoft,
+  createUnMinimax,
   createUnSpeech,
   createUnVolcengine,
 } from 'unspeech'
@@ -62,6 +63,7 @@ When using
 - [Alibaba Cloud Model Studio / 阿里云百炼 / CosyVoice](https://www.alibabacloud.com/en/product/modelstudio)
 - [Volcano Engine / 火山引擎语音技术](https://www.volcengine.com/product/voice-tech)
 - [ElevenLabs](https://elevenlabs.io/docs/api-reference/text-to-speech/convert)
+- [MiniMax](https://platform.minimaxi.com/docs/guides/speech-t2a-http)
 
 providers, [SSML](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthesis-markup) is supported to control in fine grain level for pitch, volume, rate, etc.
 

--- a/sdk/typescript/src/backend/index.ts
+++ b/sdk/typescript/src/backend/index.ts
@@ -7,6 +7,7 @@ export * from './alibabacloud'
 export * from './deepgram'
 export * from './elevenlabs'
 export * from './microsoft'
+export * from './minimax'
 export * from './volcengine'
 
 /** @see {@link https://github.com/moeru-ai/unspeech} */
@@ -26,7 +27,7 @@ export function createUnSpeech(apiKey: string, baseURL = 'http://localhost:5933/
         | 'ali'
         | 'alibaba'
         | 'alibaba-model-studio'
-        | 'aliyun' | 'bailian' | 'deepgram' | 'elevenlabs' | 'koemotion' | 'openai'
+        | 'aliyun' | 'bailian' | 'deepgram' | 'elevenlabs' | 'koemotion' | 'minimax' | 'openai'
     }
   > = {
     voice: (options) => {
@@ -60,6 +61,7 @@ export function createUnSpeech(apiKey: string, baseURL = 'http://localhost:5933/
       | `deepgram/${string}`
       | `elevenlabs/${string}`
       | `koemotion/${string}`
+      | `minimax/${string}`
       | `openai/${string}`
       | `volcano/${string}`
       | `volcengine/${string}`,

--- a/sdk/typescript/src/backend/minimax.ts
+++ b/sdk/typescript/src/backend/minimax.ts
@@ -1,0 +1,145 @@
+import type { SpeechProviderWithExtraOptions } from '@xsai-ext/providers/utils'
+
+import type { UnSpeechOptions, VoiceProviderWithExtraOptions } from '../types'
+
+import { merge } from '@xsai-ext/providers/utils'
+import { objCamelToSnake } from '@xsai/shared'
+
+/**
+ * MiniMax TTS API options
+ * @see https://platform.minimaxi.com/docs/guides/speech-t2a-http
+ */
+export interface UnMinimaxOptions {
+  /**
+   * Speech speed. Range: 0.5-2.0
+   * @default 1.0
+   */
+  speed?: number
+  /**
+   * Volume. Range: 0-10
+   * @default 1.0
+   */
+  vol?: number
+  /**
+   * Pitch adjustment. Range: -12 to 12
+   * @default 0
+   */
+  pitch?: number
+  /**
+   * Emotion setting
+   * @see https://platform.minimaxi.com/docs/guides/speech-t2a-http#emotion
+   * @example "happy" | "sad" | "angry" | "fearful" | "disgusted" | "surprised" | "calm" | "fluent" | "whisper"
+   */
+  emotion?: string
+  /**
+   * Enable streaming output
+   * @default false
+   */
+  stream?: boolean
+  /**
+   * Sample rate for audio output
+   * @example 8000 | 16000 | 22050 | 24000 | 32000 | 44100
+   */
+  sampleRate?: number
+  /**
+   * Audio bitrate
+   * @example 32000 | 64000 | 128000 | 256000
+   */
+  bitrate?: number
+  /**
+   * Audio format
+   * @example "mp3" | "pcm" | "flac" | "wav"
+   * @default "mp3"
+   */
+  format?: 'mp3' | 'pcm' | 'flac' | 'wav'
+  /**
+   * Audio channel
+   * @example 1 | 2
+   * @default 1
+   */
+  channel?: number
+}
+
+/**
+ * MiniMax TTS models
+ * @see https://platform.minimaxi.com/docs/guides/speech-t2a-http#model
+ */
+export type MinimaxModel =
+  | 'speech-2.8-hd'
+  | 'speech-2.8-turbo'
+  | 'speech-2.6-hd'
+  | 'speech-2.6-turbo'
+  | 'speech-02-hd'
+  | 'speech-02-turbo'
+  | 'speech-01-hd'
+  | 'speech-01-turbo'
+
+/**
+ * [MiniMax](https://platform.minimaxi.com/) provider for [UnSpeech](https://github.com/moeru-ai/unspeech)
+ *
+ * @param apiKey - MiniMax API Key
+ * @param baseURL - UnSpeech Instance URL
+ * @returns SpeechProviderWithExtraOptions & VoiceProviderWithExtraOptions
+ */
+export function createUnMinimax(apiKey: string, baseURL = 'http://localhost:5933/v1/') {
+  const toUnSpeechOptions = ({
+    speed,
+    vol,
+    pitch,
+    emotion,
+    stream,
+    sampleRate,
+    bitrate,
+    format,
+    channel,
+  }: UnMinimaxOptions): UnSpeechOptions => ({
+    extraBody: objCamelToSnake({
+      speed,
+      vol,
+      pitch,
+      emotion,
+      stream,
+      sampleRate,
+      bitrate,
+      format,
+      channel,
+    }),
+  })
+
+  const speechProvider: SpeechProviderWithExtraOptions<
+    `minimax/${MinimaxModel}`,
+    UnMinimaxOptions
+  > = {
+    speech: (model, options) => ({
+      ...(options ? toUnSpeechOptions(options) : {}),
+      apiKey,
+      baseURL,
+      model: `minimax/${model}`,
+    }),
+  }
+
+  const voiceProvider: VoiceProviderWithExtraOptions<
+    UnMinimaxOptions
+  > = {
+    voice: (options) => {
+      if (baseURL.endsWith('v1/')) {
+        baseURL = baseURL.slice(0, -3)
+      }
+      else if (baseURL.endsWith('v1')) {
+        baseURL = baseURL.slice(0, -2)
+      }
+
+      return {
+        query: 'provider=minimax',
+        ...(options ? toUnSpeechOptions(options) : {}),
+        apiKey,
+        baseURL,
+      }
+    },
+  }
+
+  return merge(
+    speechProvider,
+    voiceProvider,
+  )
+}


### PR DESCRIPTION
## Summary

  - Add MiniMax TTS support to unspeech backend (Go)
  - Support both streaming and non-streaming TTS
  - Add voice list API support via `/api/voices?provider=minimax`
  - Add TypeScript SDK support via `createUnMinimax()`
  - Fix Speed field type from int to float64 for better precision

  ## Changes

  | File | Description |
  |------|-------------|
  | `pkg/backend/minimax/speech.go` | TTS implementation with streaming support |
  | `pkg/backend/minimax/voices.go` | Voice list API implementation |        
  | `pkg/backend/backend.go` | Add minimax routing |
  | `pkg/backend/types/types.go` | Fix Speed field type (int → float64) |    
  | `sdk/typescript/src/backend/minimax.ts` | TypeScript SDK |
  | `README.md` | Add MiniMax to supported providers |
  | `sdk/typescript/README.md` | Add MiniMax documentation |

  ## Test Plan

  - [x] Test TTS synthesis (non-streaming)
  - [x] Test streaming TTS
  - [x] Test voice list API (`/api/voices?provider=minimax`)
  - [x] Test with parameters (speed, emotion, vol, pitch, etc.)