### PR TITLE
feat(volcengine): add integration and mock tests for speech streaming

### DIFF
--- a/cmd/unspeech/main.go
+++ b/cmd/unspeech/main.go
@@ -31,6 +31,8 @@ func main() {
 
 			// OpenAI Compatible API
 			e.POST("/v1/audio/speech", ho.MonadEcho1(backend.Speech))
+			// Bidirectional streaming TTS over WebSocket.
+			e.GET("/v1/audio/speech/stream", ho.MonadEcho1(backend.SpeechStream))
 
 			// unSpeech API
 			e.GET("/api/voices", ho.MonadEcho1(backend.Voices))

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -7,7 +7,9 @@ words:
   - apierrors
   - Apim
   - bailian
+  - bidirection
   - bumpp
+  - bytedance
   - canonicalheader
   - chardata
   - cognitiveservices
@@ -74,6 +76,7 @@ words:
   - nolint
   - nolintlint
   - nosprintfhostport
+  - openspeech
   - paralleltest
   - perfsprint
   - prealloc
@@ -95,6 +98,7 @@ words:
   - truesilk
   - tsdown
   - typecheck
+  - Upgrader
   - unconvert
   - unparam
   - unspeech

--- a/docs/wire-protocols/audio-speech-stream-v1.md
+++ b/docs/wire-protocols/audio-speech-stream-v1.md
@@ -1,0 +1,459 @@
+# Bidirectional Streaming TTS Wire Protocol — v1
+
+Endpoint: `GET wss://<host>/v1/audio/speech/stream`
+
+This document defines the WebSocket wire protocol unSpeech exposes for
+bidirectional streaming text-to-speech. It is the contract every client
+(browsers, Electron apps, server-side proxies) talks against, regardless
+of which upstream provider backs the session.
+
+The v1 protocol is currently implemented against the Volcengine
+bidirectional TTS upstream
+(<https://www.volcengine.com/docs/6561/1329505>). Additional backends
+will be added behind the same wire.
+
+## Status
+
+Stable for v1. Additive changes (new optional fields, new server event
+types that older clients can ignore) ship under v1. Breaking changes
+will be released under a different path (`/v2/audio/speech/stream`).
+
+## Transport
+
+WebSocket over TLS. The endpoint is an HTTP `GET` that the server
+upgrades. Both text frames and binary frames are used:
+
+| Frame   | Direction        | Purpose                              |
+| ------- | ---------------- | ------------------------------------ |
+| Text    | both             | Control events, JSON-encoded         |
+| Binary  | server → client  | Raw audio bytes, no framing header   |
+
+Audio is sent as raw WebSocket binary frames rather than base64 inside
+JSON to avoid the 33% size overhead of base64 in a continuously
+streaming payload.
+
+## Authentication
+
+The HTTP upgrade request must carry the upstream API key in the
+`Authorization` header:
+
+```
+Authorization: Bearer <upstream_api_key>
+```
+
+For the Volcengine backend, this value is forwarded upstream as the
+`X-Api-Key` header (new-console auth). Old-console auth
+(`X-Api-App-Id` + `X-Api-Access-Key`) is not supported on the streaming
+endpoint.
+
+### Browser clients
+
+Browsers cannot set custom headers on `new WebSocket(...)`. Browser
+clients must connect through a server-side proxy that injects the
+`Authorization` header on their behalf, holding the upstream key
+server-side. The proxy can stream its own WebSocket onward to unSpeech
+without re-buffering audio.
+
+## Routing
+
+The upstream backend is selected via the `model` field on the first
+client frame, using the same `<backend>/<model>` convention as the REST
+`POST /v1/audio/speech` endpoint:
+
+| `model` prefix                                 | Backend         |
+| ---------------------------------------------- | --------------- |
+| `volcengine/<anything>`, `volcano/<anything>`  | Volcengine v3   |
+
+For Volcengine the trailing `<anything>` is informational; the actual
+upstream model (resource id) is selected via
+`extra_body.api_resource_id` (defaults to `seed-tts-2.0`).
+
+A request whose backend does not implement streaming is rejected with
+HTTP 400 during the upgrade handshake.
+
+## Session Lifecycle
+
+```
+client                  unspeech                       upstream
+  │                        │                              │
+  ├── ws upgrade ─────────▶│                              │
+  │                        ├── ws upgrade ───────────────▶│
+  │                        │                              │
+  ├── {event:"start"} ────▶│                              │
+  │                        ├── StartConnection ──────────▶│
+  │                        │◀── ConnectionStarted ────────┤
+  │                        ├── StartSession ─────────────▶│
+  │                        │◀── SessionStarted ───────────┤
+  │◀── {event:"session.started"} ┤                        │
+  │                        │                              │
+  ├── {event:"text", text:"Hello "} ─▶                    │
+  │                        ├── TaskRequest("Hello ") ────▶│
+  │                        │◀── TTSSentenceStart ─────────┤
+  │◀── {event:"sentence.start"} ─┤                        │
+  │                        │◀── TTSResponse (audio) ──────┤
+  │◀── <binary audio>──────┤                              │
+  │◀── <binary audio>──────┤                              │
+  │                        │◀── TTSSentenceEnd ───────────┤
+  │◀── {event:"sentence.end"} ───┤                        │
+  │                        │                              │
+  ├── {event:"text", text:"world."} ─▶ …                  │
+  │                        │                              │
+  ├── {event:"finish"} ───▶│                              │
+  │                        ├── FinishSession ────────────▶│
+  │                        │◀── SessionFinished ──────────┤
+  │◀── {event:"session.finished"} ┤                       │
+  │                        ├── FinishConnection ─────────▶│
+  │                        │◀── close ────────────────────┤
+  │◀── close ──────────────┤                              │
+```
+
+A single WebSocket connection hosts exactly one session. To synthesize
+in parallel, open multiple connections.
+
+The single-session model intentionally mirrors the upstream constraint
+(Volcengine v3 forbids concurrent sessions on one upstream connection).
+A future v2 may add `context_id` multiplexing similar to Cartesia's
+design.
+
+## Client → Server Events
+
+All client-to-server frames are WebSocket **text** frames carrying JSON
+with a top-level `event` discriminator.
+
+### `start`
+
+The first frame on every connection. Carries an OpenAI-shape speech
+request body with `input` omitted (text arrives later via `text`
+frames).
+
+| Field             | Type     | Required | Notes                                                                      |
+| ----------------- | -------- | -------- | -------------------------------------------------------------------------- |
+| `event`           | string   | yes      | `"start"`                                                                  |
+| `model`           | string   | yes      | `<backend>/<id>`, e.g. `volcengine/seed-tts-2.0`                           |
+| `voice`           | string   | yes      | Upstream voice/speaker id, e.g. `zh_female_shuangkuaisisi_moon_bigtts`     |
+| `response_format` | string   | no       | OpenAI-style: `mp3` (default), `opus`, `aac`, `flac`, `wav`, `pcm`. See below |
+| `extra_body`      | object   | no       | Backend-specific knobs (see "Volcengine extra_body" below)                 |
+
+`wav` is rejected by the Volcengine upstream in streaming mode (the
+upstream re-emits a WAV header on every chunk). Use `mp3` or `pcm`.
+
+Example:
+
+```json
+{
+  "event": "start",
+  "model": "volcengine/seed-tts-2.0",
+  "voice": "zh_female_shuangkuaisisi_moon_bigtts",
+  "response_format": "mp3",
+  "extra_body": {
+    "api_resource_id": "seed-tts-2.0",
+    "audio": { "sample_rate": 24000, "bit_rate": 64000, "enable_subtitle": true }
+  }
+}
+```
+
+#### Volcengine `extra_body`
+
+All fields are optional.
+
+| Path                       | Type    | Notes                                                                       |
+| -------------------------- | ------- | --------------------------------------------------------------------------- |
+| `api_resource_id`          | string  | `seed-tts-2.0` (default), `seed-tts-1.0`, `seed-icl-2.0`, etc.              |
+| `api_connect_id`           | string  | Trace id forwarded as `X-Api-Connect-Id`; defaults to a generated UUID      |
+| `model_variant`            | string  | TTS 2.0 only: `seed-tts-2.0-standard` or `-expressive`                      |
+| `audio.sample_rate`        | int     | 8000 / 16000 / 22050 / 24000 / 32000 / 44100 / 48000 — default 24000        |
+| `audio.bit_rate`           | int     | bps; mp3/ogg recommended ≥64000                                             |
+| `audio.emotion`            | string  | Upstream emotion tag (see Volcengine voice list)                            |
+| `audio.emotion_scale`      | number  | 1–5                                                                         |
+| `audio.speech_rate`        | int     | -50 to 100                                                                  |
+| `audio.loudness_rate`      | int     | -50 to 100                                                                  |
+| `audio.enable_timestamp`   | bool    | Word timestamps on `sentence.end` (TTS 1.0 / ICL 1.0)                       |
+| `audio.enable_subtitle`    | bool    | Subtitle events (TTS 2.0 / ICL 2.0)                                         |
+| `additions`                | object  | Opaque JSON forwarded as upstream `req_params.additions`                    |
+| `section_id`               | string  | Multi-turn session id (TTS 2.0)                                             |
+| `context_texts`            | array   | Voice instruction phrases (TTS 2.0 expressive)                              |
+| `user.uid`                 | string  | Optional caller id forwarded upstream                                       |
+
+### `text`
+
+Append a chunk of text. Each `text` frame triggers exactly one upstream
+`TaskRequest`. Multiple `text` frames within a single session share
+voice state — the upstream model treats them as one synthesis pass,
+which yields more natural prosody than re-opening a session per chunk.
+
+```json
+{ "event": "text", "text": "明朝开国皇帝朱元璋也称这本书为，万物之根" }
+```
+
+| Field   | Type   | Required | Notes                                |
+| ------- | ------ | -------- | ------------------------------------ |
+| `event` | string | yes      | `"text"`                             |
+| `text`  | string | yes      | Non-empty; empty values are ignored  |
+
+The Volcengine docs recommend feeding raw LLM streaming output through
+this without client-side sentence boundary detection. The upstream
+fragments internally to balance latency against naturalness.
+
+### `finish`
+
+End the session cleanly. The server emits any remaining audio, then a
+final `session.finished` event, then closes the connection.
+
+```json
+{ "event": "finish" }
+```
+
+### `cancel`
+
+Abort the in-flight session. The server forwards `CancelSession`
+upstream and closes the connection immediately. **No
+`session.finished` will follow.** Use this when the user interrupts
+mid-stream.
+
+```json
+{ "event": "cancel" }
+```
+
+> Known limitation: v1 does not wait for the upstream `SessionCanceled`
+> ack before closing. Clients learn that cancellation succeeded only
+> via the absence of further frames and the WebSocket close. This is
+> acceptable because no useful client action depends on the ack — a
+> future v2 may surface `session.canceled` if a use case appears.
+
+## Server → Client Events
+
+All server-to-client control frames are WebSocket **text** frames with
+the same `event` discriminator. Audio data uses **binary** frames with
+no envelope.
+
+### `session.started` (text)
+
+Sent once, after the upstream session is established. After this event
+the client may begin sending `text` frames.
+
+```json
+{ "event": "session.started" }
+```
+
+### `sentence.start` (text)
+
+Marks the beginning of a sentence in the upstream output. The
+`payload` field carries the upstream event payload verbatim.
+
+```json
+{ "event": "sentence.start", "payload": { … upstream payload … } }
+```
+
+### `sentence.end` (text)
+
+Marks the end of a sentence. When
+`extra_body.audio.enable_timestamp = true` (TTS 1.0 / ICL 1.0), the
+payload includes word-level timestamps aligned to the synthesized audio
+(`startTime` / `endTime` in seconds, relative to the session start).
+
+```json
+{
+  "event": "sentence.end",
+  "payload": {
+    "text": "明朝开国皇帝朱元璋",
+    "words": [
+      { "word": "明", "startTime": 0.155, "endTime": 0.295 },
+      { "word": "朝", "startTime": 0.295, "endTime": 0.425 }
+    ]
+  }
+}
+```
+
+### `subtitle` (text)
+
+TTS 2.0 / ICL 2.0 only. Original-text-aligned timestamps that arrive
+asynchronously from the audio. May lag the audio for the same
+sentence; clients that drive captions should buffer audio playback to
+align with subtitle arrival, or accept that captions are best-effort.
+
+```json
+{ "event": "subtitle", "payload": { … upstream payload … } }
+```
+
+### `session.finished` (text)
+
+The final event of a normal session. The payload mirrors the upstream
+`SessionFinished` body and may include usage when requested upstream.
+
+```json
+{
+  "event": "session.finished",
+  "payload": {
+    "status_code": 20000000,
+    "message": "ok",
+    "usage": { "text_words": 195 }
+  }
+}
+```
+
+> The bridge sets `X-Control-Require-Usage-Tokens-Return: *` on the upstream
+> handshake, so Volcengine returns the character count alongside the session
+> close. Providers other than Volcengine may not surface `usage` — clients
+> should treat the field as optional.
+
+### `error` (text)
+
+```json
+{ "event": "error", "code": "upstream_error", "message": "…" }
+```
+
+| `code`              | Trigger                                              |
+| ------------------- | ---------------------------------------------------- |
+| `upstream_error`    | Upstream sent an error frame (binary `msgType=1111`) |
+| `connection_failed` | Upstream `ConnectionFailed` event                    |
+| `session_failed`    | Upstream `SessionFailed` event                       |
+| `invalid_event`     | Client sent malformed JSON                           |
+| `unknown_event`     | Client used an unrecognized `event` value            |
+
+After a fatal `error` (`upstream_error`, `connection_failed`,
+`session_failed`) the server closes the connection. `invalid_event`
+and `unknown_event` are recoverable — the connection stays open.
+
+### Binary audio frames (binary)
+
+Each binary WebSocket frame is a chunk of raw audio in the format
+selected by `response_format` (default `mp3`). There is **no framing
+header**: concatenating every binary frame of a session in arrival
+order yields the complete audio.
+
+For `pcm`, the byte stream is signed 16-bit little-endian samples at
+the requested sample rate. For `mp3` and `ogg_opus`, each frame is a
+self-contained chunk that decoders can be fed incrementally (e.g. via
+MediaSource Extensions or `mpg123`-style chunked decoding).
+
+## Error Handling
+
+* The WebSocket handshake itself only fails for transport-level reasons
+  (TLS, route not mounted). Application-level errors — missing
+  `Authorization`, unsupported `model` backend, malformed `start` frame,
+  upstream connect failure — surface **after** upgrade: the server emits
+  an `error` JSON frame on the open WebSocket and then closes. Clients
+  should treat receipt of `error` followed by close as the error signal,
+  not the HTTP handshake.
+* Once the WebSocket is open, all errors flow through `error` events.
+* The client should always handle the WebSocket close event as the
+  final ground truth — `session.finished` and `error` are advisory.
+* A close arriving without a preceding `session.finished` means the
+  session was truncated. Clients must NOT treat partially accumulated
+  audio as a success.
+
+## Sample Client (TypeScript, browser)
+
+For browser environments, replace `Authorization` with a proxy that
+injects it server-side.
+
+```ts
+const ws = new WebSocket('wss://unspeech.example.com/v1/audio/speech/stream')
+ws.binaryType = 'arraybuffer'
+
+const audioChunks: Uint8Array[] = []
+
+ws.addEventListener('open', () => {
+  ws.send(JSON.stringify({
+    event: 'start',
+    model: 'volcengine/seed-tts-2.0',
+    voice: 'zh_female_shuangkuaisisi_moon_bigtts',
+    response_format: 'mp3',
+    extra_body: {
+      api_resource_id: 'seed-tts-2.0',
+      audio: { sample_rate: 24000, bit_rate: 64000 },
+    },
+  }))
+})
+
+ws.addEventListener('message', (e) => {
+  if (typeof e.data === 'string') {
+    const event = JSON.parse(e.data)
+    switch (event.event) {
+      case 'session.started':
+        ws.send(JSON.stringify({ event: 'text', text: 'Hello, world.' }))
+        ws.send(JSON.stringify({ event: 'finish' }))
+        break
+      case 'sentence.end':
+        // event.payload.words has timestamps
+        break
+      case 'session.finished':
+        ws.close()
+        break
+      case 'error':
+        console.error('tts error', event.code, event.message)
+        break
+    }
+  }
+  else {
+    audioChunks.push(new Uint8Array(e.data as ArrayBuffer))
+  }
+})
+```
+
+## Sample Client (Go, server-side proxy)
+
+```go
+header := http.Header{}
+header.Set("Authorization", "Bearer "+upstreamKey)
+
+ws, _, err := websocket.DefaultDialer.Dial(
+    "wss://unspeech.example.com/v1/audio/speech/stream", header)
+if err != nil {
+    return err
+}
+defer ws.Close()
+
+start, _ := json.Marshal(map[string]any{
+    "event":           "start",
+    "model":           "volcengine/seed-tts-2.0",
+    "voice":           voiceID,
+    "response_format": "mp3",
+    "extra_body": map[string]any{
+        "api_resource_id": "seed-tts-2.0",
+    },
+})
+if err := ws.WriteMessage(websocket.TextMessage, start); err != nil {
+    return err
+}
+```
+
+## Compatibility & Versioning
+
+The wire protocol is versioned by URL path. v1 is the current shipping
+version.
+
+* Additive changes (new optional fields, new event types older clients
+  can ignore) ship under v1.
+* Breaking changes (renamed events, removed fields, repurposed
+  semantics) will live at `/v2/audio/speech/stream` and run alongside
+  v1 until v1 is retired.
+
+The `event` discriminator on both directions is deliberately
+extensible: clients should ignore unknown server events rather than
+fail, and servers should reject unknown client events with
+`unknown_event`.
+
+## Open Questions / Future Work
+
+* [ ] Surface the Volcengine binary `errorCode` (from `msgType=0b1111`
+      frames) inside the JSON `error` event payload so clients can
+      distinguish auth, quota, and malformed-session errors without
+      parsing provider-specific text.
+* [ ] Add ElevenLabs / Cartesia / Azure backends behind the same wire.
+* [ ] `context_id` multiplexing for parallel sessions on one
+      connection (v2).
+* [ ] Heartbeat / `ping` event for idle keep-alive on long pauses
+      between client `text` frames.
+* [ ] Surface `session.canceled` ack from upstream after `cancel`.
+
+## References
+
+* Volcengine v3 bidirectional TTS:
+  <https://www.volcengine.com/docs/6561/1329505>
+* OpenAI `/v1/audio/speech` request shape (the REST sibling this
+  protocol extends): <https://platform.openai.com/docs/api-reference/audio/createSpeech>
+* Cartesia TTS WebSocket (reference design for `context_id`):
+  <https://docs.cartesia.ai/api-reference/tts/websocket>
+* Deepgram Aura WebSocket (reference for binary audio frames):
+  <https://developers.deepgram.com/docs/tts-websocket>

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -1,6 +1,10 @@
 package backend
 
 import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/mo"
 
@@ -15,6 +19,15 @@ import (
 	"github.com/moeru-ai/unspeech/pkg/backend/volcengine"
 	"github.com/moeru-ai/unspeech/pkg/utils"
 )
+
+const (
+	backendVolcengine = "volcengine"
+	backendVolcano    = "volcano"
+)
+
+var speechStreamUpgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
 
 func Speech(c echo.Context) mo.Result[any] {
 	options := types.NewSpeechRequestOptions(c.Request().Body)
@@ -33,13 +46,103 @@ func Speech(c echo.Context) mo.Result[any] {
 		return koemotion.HandleSpeech(c, utils.ResultToOption(options))
 	case "microsoft", "azure":
 		return microsoft.HandleSpeech(c, utils.ResultToOption(options))
-	case "volcengine", "volcano":
+	case backendVolcengine, backendVolcano:
 		return volcengine.HandleSpeech(c, utils.ResultToOption(options))
 	case "ali", "aliyun", "alibaba", "bailian", "alibaba-model-studio":
 		return alibaba.HandleSpeech(c, utils.ResultToOption(options))
 	default:
 		return mo.Err[any](apierrors.NewErrBadRequest().WithDetail("unsupported backend"))
 	}
+}
+
+func SpeechStream(c echo.Context) mo.Result[any] {
+	ws, err := speechStreamUpgrader.Upgrade(c.Response(), c.Request(), nil)
+	if err != nil {
+		// Upgrade itself writes a response on failure (echo can still write
+		// because the conn is not yet hijacked when upgrade fails).
+		return mo.Err[any](apierrors.NewErrBadRequest().WithDetail(err.Error()))
+	}
+
+	defer func() { _ = ws.Close() }()
+
+	// Post-upgrade, the underlying conn is hijacked: echo's error middleware
+	// MUST NOT try to write an HTTP response on it (would dump a stack trace
+	// over the websocket bytes and the client sees an abnormal close with no
+	// reason). All failures from here on are surfaced via JSON `error` events
+	// on the open ws, followed by a clean close. We always return mo.Ok so
+	// the echo handler chain treats the request as completed normally.
+	failClient := func(code, message string) mo.Result[any] {
+		errEvent, marshalErr := json.Marshal(types.SpeechStreamServerEvent{
+			Event:   types.SpeechStreamServerEventError,
+			Code:    code,
+			Message: message,
+		})
+		if marshalErr == nil {
+			_ = ws.WriteMessage(websocket.TextMessage, errEvent)
+		}
+		// Reason length is limited to 123 bytes by the protocol; truncate to
+		// be safe. Use policy-violation code so the browser surfaces it
+		// distinctly from network errors.
+		closeMsg := websocket.FormatCloseMessage(websocket.ClosePolicyViolation, truncateCloseReason(message))
+		_ = ws.WriteMessage(websocket.CloseMessage, closeMsg)
+
+		return mo.Ok[any](nil)
+	}
+
+	msgType, payload, err := ws.ReadMessage()
+	if err != nil {
+		return failClient("read_first_frame_failed", err.Error())
+	}
+
+	if msgType != websocket.TextMessage {
+		return failClient("invalid_first_frame", "first frame must be a JSON text frame")
+	}
+
+	var envelope struct {
+		Event string `json:"event"`
+	}
+
+	unmarshalErr := json.Unmarshal(payload, &envelope)
+	if unmarshalErr != nil {
+		return failClient("invalid_first_frame", unmarshalErr.Error())
+	}
+
+	if envelope.Event != string(types.SpeechStreamClientEventStart) {
+		return failClient("invalid_first_frame", "first frame must be event=start")
+	}
+
+	options := types.NewSpeechStreamStartOptions(payload)
+	if options.IsError() {
+		return failClient("invalid_start_options", options.Error().Error())
+	}
+
+	switch options.MustGet().Backend {
+	case backendVolcengine, backendVolcano:
+		// Backend takes over the ws from here. It also surfaces any further
+		// errors via `error` events on the same ws (see HandleSpeechStream).
+		result := volcengine.HandleSpeechStream(c, ws, utils.ResultToOption(options))
+		if result.IsError() {
+			// Backend already sent its own error event; just absorb the error
+			// so the echo chain doesn't try to write to the hijacked conn.
+			return mo.Ok[any](nil)
+		}
+
+		return result
+	default:
+		return failClient("unsupported_backend", "streaming is only supported for backend=volcengine")
+	}
+}
+
+// truncateCloseReason caps a WebSocket close reason to the 123-byte protocol
+// limit (RFC 6455 §5.5: control frame payload max is 125 bytes; close frame
+// reserves 2 bytes for the status code).
+func truncateCloseReason(s string) string {
+	const maxReasonBytes = 123
+	if len(s) <= maxReasonBytes {
+		return s
+	}
+
+	return s[:maxReasonBytes]
 }
 
 func Voices(c echo.Context) mo.Result[any] {
@@ -59,7 +162,7 @@ func Voices(c echo.Context) mo.Result[any] {
 		return koemotion.HandleVoices(c, utils.ResultToOption(options))
 	case "microsoft", "azure":
 		return microsoft.HandleVoices(c, utils.ResultToOption(options))
-	case "volcengine", "volcano":
+	case backendVolcengine, backendVolcano:
 		return volcengine.HandleVoices(c, utils.ResultToOption(options))
 	case "ali", "aliyun", "alibaba", "bailian", "alibaba-model-studio":
 		return alibaba.HandleVoices(c, utils.ResultToOption(options))

--- a/pkg/backend/types/stream.go
+++ b/pkg/backend/types/stream.go
@@ -1,0 +1,85 @@
+package types
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+
+	"github.com/moeru-ai/unspeech/pkg/apierrors"
+)
+
+// SpeechStreamClientEventType is the discriminator for events the client
+// sends to unspeech on a streaming TTS WebSocket (JSON text frames).
+type SpeechStreamClientEventType string
+
+const (
+	SpeechStreamClientEventStart  SpeechStreamClientEventType = "start"
+	SpeechStreamClientEventText   SpeechStreamClientEventType = "text"
+	SpeechStreamClientEventFinish SpeechStreamClientEventType = "finish"
+	SpeechStreamClientEventCancel SpeechStreamClientEventType = "cancel"
+)
+
+type SpeechStreamClientEvent struct {
+	Event SpeechStreamClientEventType `json:"event"`
+	Text  string                      `json:"text,omitempty"`
+}
+
+// SpeechStreamServerEventType is the discriminator for events unspeech sends
+// back to the client (JSON text frames). Audio bytes travel as binary frames
+// and do not use this envelope.
+type SpeechStreamServerEventType string
+
+const (
+	SpeechStreamServerEventSessionStarted  SpeechStreamServerEventType = "session.started"
+	SpeechStreamServerEventSentenceStart   SpeechStreamServerEventType = "sentence.start"
+	SpeechStreamServerEventSentenceEnd     SpeechStreamServerEventType = "sentence.end"
+	SpeechStreamServerEventSubtitle        SpeechStreamServerEventType = "subtitle"
+	SpeechStreamServerEventSessionFinished SpeechStreamServerEventType = "session.finished"
+	SpeechStreamServerEventError           SpeechStreamServerEventType = "error"
+)
+
+type SpeechStreamServerEvent struct {
+	Event   SpeechStreamServerEventType `json:"event"`
+	Text    string                      `json:"text,omitempty"`
+	Code    string                      `json:"code,omitempty"`
+	Message string                      `json:"message,omitempty"`
+	Payload map[string]any              `json:"payload,omitempty"`
+}
+
+// NewSpeechStreamStartOptions parses the WS `start` frame. Unlike
+// NewSpeechRequestOptions, `input` is optional because text flows through later
+// `text` frames.
+func NewSpeechStreamStartOptions(payload []byte) mo.Result[SpeechRequestOptions] {
+	var optionsMap map[string]any
+
+	err := json.Unmarshal(payload, &optionsMap)
+	if err != nil {
+		return mo.Err[SpeechRequestOptions](apierrors.NewErrBadRequest().WithDetail(err.Error()))
+	}
+
+	var options OpenAISpeechRequestOptions
+
+	err = json.Unmarshal(payload, &options)
+	if err != nil {
+		return mo.Err[SpeechRequestOptions](apierrors.NewErrBadRequest().WithDetail(err.Error()))
+	}
+
+	if options.Model == "" || options.Voice == "" {
+		return mo.Err[SpeechRequestOptions](apierrors.NewErrInvalidArgument().WithDetail("model and voice parameter are required"))
+	}
+
+	backendAndModel := lo.Ternary(
+		strings.Contains(options.Model, "/"),
+		strings.SplitN(options.Model, "/", 2), //nolint:mnd
+		[]string{options.Model, ""},
+	)
+
+	return mo.Ok(SpeechRequestOptions{
+		OpenAISpeechRequestOptions: options,
+		Backend:                    backendAndModel[0],
+		Model:                      backendAndModel[1],
+		bodyParsedMap:              optionsMap,
+	})
+}

--- a/pkg/backend/volcengine/speech_stream.go
+++ b/pkg/backend/volcengine/speech_stream.go
@@ -1,0 +1,609 @@
+package volcengine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+
+	"github.com/moeru-ai/unspeech/pkg/apierrors"
+	"github.com/moeru-ai/unspeech/pkg/backend/types"
+	"github.com/moeru-ai/unspeech/pkg/utils"
+)
+
+// v3BidirectionEndpoint is the Volcengine v3 bidirectional TTS endpoint.
+// Declared as `var` (not `const`) so the in-package mock-upstream
+// integration tests can swap it for a local httptest server. The runtime
+// value is never mutated outside tests.
+var v3BidirectionEndpoint = "wss://openspeech.bytedance.com/api/v3/tts/bidirection" //nolint:gochecknoglobals
+
+type v3ReqParamsAudio struct {
+	Format          string  `json:"format,omitempty"`
+	SampleRate      int     `json:"sample_rate,omitempty"`
+	BitRate         int     `json:"bit_rate,omitempty"`
+	Emotion         string  `json:"emotion,omitempty"`
+	EmotionScale    float64 `json:"emotion_scale,omitempty"`
+	SpeechRate      int     `json:"speech_rate,omitempty"`
+	LoudnessRate    int     `json:"loudness_rate,omitempty"`
+	EnableTimestamp bool    `json:"enable_timestamp,omitempty"`
+	EnableSubtitle  bool    `json:"enable_subtitle,omitempty"`
+}
+
+type v3ReqParams struct {
+	Text         string            `json:"text"`
+	Model        string            `json:"model,omitempty"`
+	Speaker      string            `json:"speaker"`
+	AudioParams  *v3ReqParamsAudio `json:"audio_params,omitempty"`
+	Additions    string            `json:"additions,omitempty"`
+	SectionID    string            `json:"section_id,omitempty"`
+	ContextTexts []string          `json:"context_texts,omitempty"`
+}
+
+type v3SessionPayload struct {
+	User      map[string]any `json:"user,omitempty"`
+	Event     v3Event        `json:"event"`
+	Namespace string         `json:"namespace,omitempty"`
+	ReqParams v3ReqParams    `json:"req_params"`
+}
+
+// HandleSpeechStream bridges a client WebSocket to Volcengine V3 bidirectional
+// TTS. The caller is expected to have already upgraded the HTTP connection and
+// consumed the `start` frame.
+func HandleSpeechStream(c echo.Context, clientWS *websocket.Conn, options mo.Option[types.SpeechRequestOptions]) mo.Result[any] {
+	opts := options.MustGet()
+
+	// Post-upgrade error surface: all failures from here on go to the client
+	// as JSON `error` events plus a clean close frame. Echo's HTTP error
+	// middleware MUST NOT see them (the connection is hijacked; writing an
+	// HTTP response over it dumps a stack trace into the ws bytes).
+	failClient := func(code, message string) mo.Result[any] {
+		errEvent, marshalErr := json.Marshal(types.SpeechStreamServerEvent{
+			Event:   types.SpeechStreamServerEventError,
+			Code:    code,
+			Message: message,
+		})
+		if marshalErr == nil {
+			_ = clientWS.WriteMessage(websocket.TextMessage, errEvent)
+		}
+
+		_ = clientWS.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.ClosePolicyViolation, truncateWsCloseReason(message)),
+		)
+
+		return mo.Ok[any](nil)
+	}
+
+	apiKey := strings.TrimPrefix(c.Request().Header.Get("Authorization"), "Bearer ")
+	if apiKey == "" {
+		return failClient("missing_api_key", "missing X-Api-Key in Authorization header")
+	}
+
+	resourceID := utils.GetByJSONPath[string](opts.ExtraBody, "{ .api_resource_id }")
+	if resourceID == "" {
+		resourceID = "seed-tts-2.0"
+	}
+
+	connectID := utils.GetByJSONPath[string](opts.ExtraBody, "{ .api_connect_id }")
+	if connectID == "" {
+		connectID = uuid.New().String()
+	}
+
+	upstreamHeaders := http.Header{}
+	upstreamHeaders.Set("X-Api-Key", apiKey)
+	upstreamHeaders.Set("X-Api-Resource-Id", resourceID)
+	upstreamHeaders.Set("X-Api-Connect-Id", connectID)
+	// Request usage in SessionFinished so downstream billing proxies can meter
+	// the session by text_words. Documented at
+	// https://www.volcengine.com/docs/6561/1329505 ("X-Control-Require-Usage-Tokens-Return").
+	upstreamHeaders.Set("X-Control-Require-Usage-Tokens-Return", "*")
+
+	upstream, resp, err := websocket.DefaultDialer.DialContext(c.Request().Context(), v3BidirectionEndpoint, upstreamHeaders)
+	if err != nil {
+		if resp == nil {
+			return failClient("upstream_dial_failed", err.Error())
+		}
+
+		defer func() { _ = resp.Body.Close() }()
+
+		errResult := utils.NewJSONResponseError(resp.StatusCode, resp.Body)
+		jsonErr, parseErr := errResult.Get()
+
+		detail := err.Error()
+		if parseErr == nil {
+			detail = jsonErr.Error()
+		}
+
+		return failClient(fmt.Sprintf("upstream_handshake_%d", resp.StatusCode), detail)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+		_ = upstream.Close()
+	}()
+
+	sessionID := uuid.New().String()
+	bridge := &v3Bridge{
+		client:    clientWS,
+		upstream:  upstream,
+		sessionID: sessionID,
+		startOpts: opts,
+		startedCh: make(chan struct{}, 1),
+		doneCh:    make(chan struct{}),
+	}
+
+	bridgeErr := bridge.start(c.Request().Context())
+	if bridgeErr != nil {
+		bridge.sendClientError("upstream_error", bridgeErr.Error())
+		_ = clientWS.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseInternalServerErr, truncateWsCloseReason(bridgeErr.Error())),
+		)
+
+		return mo.Ok[any](nil)
+	}
+
+	return mo.Ok[any](nil)
+}
+
+// truncateWsCloseReason caps a WebSocket close reason to the 123-byte protocol
+// limit (RFC 6455 §5.5: control frame payload max is 125 bytes; close frame
+// reserves 2 bytes for the status code).
+func truncateWsCloseReason(s string) string {
+	const maxReasonBytes = 123
+	if len(s) <= maxReasonBytes {
+		return s
+	}
+
+	return s[:maxReasonBytes]
+}
+
+type v3Bridge struct {
+	client    *websocket.Conn
+	upstream  *websocket.Conn
+	sessionID string
+	startOpts types.SpeechRequestOptions
+	startedCh chan struct{}
+	// doneCh is closed when `start` returns, signalling the client loop that
+	// the bridge is tearing down so it can exit the post-`finish` drain state.
+	doneCh chan struct{}
+
+	writeMu sync.Mutex
+}
+
+func (b *v3Bridge) start(ctx context.Context) error {
+	// Signal client loop to exit its post-`finish` drain state when this
+	// function returns (either because the upstream session finished or
+	// because we hit an error tear-down). Without this, a client that sent
+	// `finish` would block forever in the drain select even after we close
+	// the bridge.
+	defer close(b.doneCh)
+
+	err := b.sendUpstream(v3Frame{
+		msgType: v3MsgTypeFullClient,
+		flags:   v3FlagWithEvent,
+		serial:  v3SerialJSON,
+		event:   v3EventStartConnection,
+		payload: []byte(`{}`),
+	})
+	if err != nil {
+		return err
+	}
+
+	upstreamErrCh := make(chan error, 1)
+	clientErrCh := make(chan error, 1)
+
+	go func() { upstreamErrCh <- b.readUpstreamLoop(ctx) }()
+	go func() { clientErrCh <- b.readClientLoop(ctx) }()
+
+	// Whichever loop exits first ends the bridge:
+	//
+	// - Upstream loop exits naturally when `SessionFinished` /
+	//   `SessionFailed` / `ConnectionFailed` arrives, which is the **normal**
+	//   completion path. The client loop is in its post-`finish` drain
+	//   waiting for this exact moment (see readClientLoop).
+	// - Client loop exits on `cancel` (forced tear-down) or on a non-graceful
+	//   client ws error (network drop). Both are abort paths.
+	select {
+	case err := <-upstreamErrCh:
+		return err
+	case err := <-clientErrCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (b *v3Bridge) sendUpstream(f v3Frame) error {
+	b.writeMu.Lock()
+	defer b.writeMu.Unlock()
+
+	return b.upstream.WriteMessage(websocket.BinaryMessage, encodeV3Frame(f))
+}
+
+func (b *v3Bridge) sendClientJSON(event types.SpeechStreamServerEvent) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		slog.Warn("v3 bridge: failed to marshal client event", slog.String("err", err.Error()))
+
+		return
+	}
+
+	err = b.client.WriteMessage(websocket.TextMessage, data)
+	if err != nil {
+		slog.Warn("v3 bridge: failed to write client event", slog.String("err", err.Error()))
+	}
+}
+
+func (b *v3Bridge) sendClientError(code, message string) {
+	b.sendClientJSON(types.SpeechStreamServerEvent{
+		Event:   types.SpeechStreamServerEventError,
+		Code:    code,
+		Message: message,
+	})
+}
+
+func (b *v3Bridge) sendClientAudio(audio []byte) {
+	err := b.client.WriteMessage(websocket.BinaryMessage, audio)
+	if err != nil {
+		slog.Warn("v3 bridge: failed to write client audio", slog.String("err", err.Error()))
+	}
+}
+
+func (b *v3Bridge) buildStartSessionPayload() ([]byte, error) {
+	opts := b.startOpts
+
+	audio := v3ReqParamsAudio{
+		Format:     lo.Ternary(opts.ResponseFormat != "", opts.ResponseFormat, "mp3"),
+		SampleRate: lo.FromPtr(utils.GetByJSONPath[*int](opts.ExtraBody, "{ .audio.sample_rate }")),
+		BitRate:    lo.FromPtr(utils.GetByJSONPath[*int](opts.ExtraBody, "{ .audio.bit_rate }")),
+		Emotion:    utils.GetByJSONPath[string](opts.ExtraBody, "{ .audio.emotion }"),
+	}
+
+	if v := utils.GetByJSONPath[*float64](opts.ExtraBody, "{ .audio.emotion_scale }"); v != nil {
+		audio.EmotionScale = *v
+	}
+
+	if v := utils.GetByJSONPath[*int](opts.ExtraBody, "{ .audio.speech_rate }"); v != nil {
+		audio.SpeechRate = *v
+	}
+
+	if v := utils.GetByJSONPath[*int](opts.ExtraBody, "{ .audio.loudness_rate }"); v != nil {
+		audio.LoudnessRate = *v
+	}
+
+	if v := utils.GetByJSONPath[*bool](opts.ExtraBody, "{ .audio.enable_timestamp }"); v != nil {
+		audio.EnableTimestamp = *v
+	}
+
+	if v := utils.GetByJSONPath[*bool](opts.ExtraBody, "{ .audio.enable_subtitle }"); v != nil {
+		audio.EnableSubtitle = *v
+	}
+
+	additionsMap := utils.GetByJSONPath[map[string]any](opts.ExtraBody, "{ .additions }")
+
+	additionsRaw, err := json.Marshal(additionsMap)
+	if err != nil {
+		return nil, err
+	}
+
+	params := v3ReqParams{
+		Speaker:     opts.Voice,
+		Model:       utils.GetByJSONPath[string](opts.ExtraBody, "{ .model_variant }"),
+		AudioParams: &audio,
+	}
+
+	if string(additionsRaw) != "null" {
+		params.Additions = string(additionsRaw)
+	}
+
+	if v := utils.GetByJSONPath[string](opts.ExtraBody, "{ .section_id }"); v != "" {
+		params.SectionID = v
+	}
+
+	if v := utils.GetByJSONPath[[]any](opts.ExtraBody, "{ .context_texts }"); len(v) > 0 {
+		params.ContextTexts = lo.FilterMap(v, func(item any, _ int) (string, bool) {
+			s, ok := item.(string)
+
+			return s, ok
+		})
+	}
+
+	payload := v3SessionPayload{
+		Event:     v3EventStartSession,
+		Namespace: "BidirectionalTTS",
+		ReqParams: params,
+	}
+
+	if uid := utils.GetByJSONPath[string](opts.ExtraBody, "{ .user.uid }"); uid != "" {
+		payload.User = map[string]any{"uid": uid}
+	}
+
+	return json.Marshal(payload)
+}
+
+func (b *v3Bridge) buildTaskRequestPayload(text string) ([]byte, error) {
+	payload := v3SessionPayload{
+		Event:     v3EventTaskRequest,
+		Namespace: "BidirectionalTTS",
+		ReqParams: v3ReqParams{
+			Text:    text,
+			Speaker: b.startOpts.Voice,
+		},
+	}
+
+	return json.Marshal(payload)
+}
+
+func (b *v3Bridge) readUpstreamLoop(_ context.Context) error {
+	for {
+		msgType, data, err := b.upstream.ReadMessage()
+		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				return nil
+			}
+
+			return apierrors.NewErrBadGateway().WithDetail(err.Error())
+		}
+
+		if msgType != websocket.BinaryMessage {
+			continue
+		}
+
+		f, decodeErr := decodeV3Frame(data)
+		if decodeErr != nil {
+			slog.Warn("v3 bridge: decode upstream frame", slog.String("err", decodeErr.Error()))
+
+			continue
+		}
+
+		dispatchErr := b.dispatchUpstream(f)
+		if dispatchErr != nil {
+			return dispatchErr
+		}
+
+		if f.event == v3EventSessionFinished || f.event == v3EventSessionFailed || f.event == v3EventConnectionFailed {
+			return nil
+		}
+	}
+}
+
+func (b *v3Bridge) dispatchUpstream(f v3Frame) error {
+	if f.msgType == v3MsgTypeError {
+		b.sendClientError("upstream_error", string(f.payload))
+
+		return apierrors.NewErrBadGateway().WithDetailf("upstream error code=%d payload=%s", f.errorCode, string(f.payload))
+	}
+
+	switch f.event { //nolint:exhaustive
+	case v3EventConnectionStarted:
+		payload, err := b.buildStartSessionPayload()
+		if err != nil {
+			return err
+		}
+
+		return b.sendUpstream(v3Frame{
+			msgType:   v3MsgTypeFullClient,
+			flags:     v3FlagWithEvent,
+			serial:    v3SerialJSON,
+			event:     v3EventStartSession,
+			sessionID: b.sessionID,
+			payload:   payload,
+		})
+
+	case v3EventConnectionFailed:
+		b.sendClientError("connection_failed", string(f.payload))
+
+		return apierrors.NewErrBadGateway().WithDetail(string(f.payload))
+
+	case v3EventSessionStarted:
+		b.sendClientJSON(types.SpeechStreamServerEvent{Event: types.SpeechStreamServerEventSessionStarted})
+
+		select {
+		case b.startedCh <- struct{}{}:
+		default:
+		}
+
+	case v3EventTTSResponse:
+		b.sendClientAudio(f.payload)
+
+	case v3EventTTSSentenceStart:
+		b.sendClientJSON(types.SpeechStreamServerEvent{
+			Event:   types.SpeechStreamServerEventSentenceStart,
+			Payload: decodeJSONObject(f.payload),
+		})
+
+	case v3EventTTSSentenceEnd:
+		b.sendClientJSON(types.SpeechStreamServerEvent{
+			Event:   types.SpeechStreamServerEventSentenceEnd,
+			Payload: decodeJSONObject(f.payload),
+		})
+
+	case v3EventSessionFinished:
+		b.sendClientJSON(types.SpeechStreamServerEvent{
+			Event:   types.SpeechStreamServerEventSessionFinished,
+			Payload: decodeJSONObject(f.payload),
+		})
+
+		_ = b.sendUpstream(v3Frame{
+			msgType: v3MsgTypeFullClient,
+			flags:   v3FlagWithEvent,
+			serial:  v3SerialJSON,
+			event:   v3EventFinishConnection,
+			payload: []byte(`{}`),
+		})
+
+	case v3EventSessionFailed:
+		b.sendClientError("session_failed", string(f.payload))
+
+		return apierrors.NewErrBadGateway().WithDetail(string(f.payload))
+	}
+
+	return nil
+}
+
+func (b *v3Bridge) readClientLoop(ctx context.Context) error {
+	// Wait for upstream session before forwarding text — sending TaskRequest
+	// before SessionStarted yields an upstream error.
+	select {
+	case <-b.startedCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	// Tracks whether the client has signalled `finish`. After finish, we MUST
+	// NOT return — the upstream loop owns normal completion (it drains
+	// remaining audio and emits `SessionFinished`). If we returned here, the
+	// outer `start` select would close the upstream ws before that audio
+	// arrives, truncating the session (codex review: CRITICAL #1).
+	clientFinished := false
+
+	for {
+		msgType, data, err := b.client.ReadMessage()
+		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				if clientFinished {
+					// Client closed after finish — normal teardown. Let the
+					// upstream loop drive completion; block until it does.
+					<-b.doneCh
+
+					return nil
+				}
+
+				return b.finishSession()
+			}
+
+			if clientFinished {
+				// Underlying ws read errored after the client said finish.
+				// This is expected when the bridge tears down (upstream loop
+				// closed the connections via the outer defer). Treat as
+				// normal completion driven by the upstream loop.
+				<-b.doneCh
+
+				return nil
+			}
+
+			return apierrors.NewErrBadRequest().WithDetail(err.Error())
+		}
+
+		if msgType != websocket.TextMessage {
+			continue
+		}
+
+		var event types.SpeechStreamClientEvent
+
+		unmarshalErr := json.Unmarshal(data, &event)
+		if unmarshalErr != nil {
+			b.sendClientError("invalid_event", unmarshalErr.Error())
+
+			continue
+		}
+
+		// Post-finish drain: only `cancel` is still meaningful. Users abort
+		// mid-synthesis by routing a `cancel` after `finish` (Stage.vue's
+		// pipeline sends finish immediately after text, so AbortController
+		// firing later can only land here). Swallowing it would leave the
+		// upstream session running until SessionFinished, defeating abort.
+		// Codex review verified call #2.
+		if clientFinished {
+			if event.Event == types.SpeechStreamClientEventCancel {
+				_ = b.sendUpstream(v3Frame{
+					msgType:   v3MsgTypeFullClient,
+					flags:     v3FlagWithEvent,
+					serial:    v3SerialJSON,
+					event:     v3EventCancelSession,
+					sessionID: b.sessionID,
+					payload:   []byte(`{}`),
+				})
+
+				return nil
+			}
+
+			continue
+		}
+
+		switch event.Event { //nolint:exhaustive
+		case types.SpeechStreamClientEventText:
+			if event.Text == "" {
+				continue
+			}
+
+			payload, buildErr := b.buildTaskRequestPayload(event.Text)
+			if buildErr != nil {
+				return buildErr
+			}
+
+			sendErr := b.sendUpstream(v3Frame{
+				msgType:   v3MsgTypeFullClient,
+				flags:     v3FlagWithEvent,
+				serial:    v3SerialJSON,
+				event:     v3EventTaskRequest,
+				sessionID: b.sessionID,
+				payload:   payload,
+			})
+			if sendErr != nil {
+				return sendErr
+			}
+
+		case types.SpeechStreamClientEventFinish:
+			if finishErr := b.finishSession(); finishErr != nil {
+				return finishErr
+			}
+
+			clientFinished = true
+
+		case types.SpeechStreamClientEventCancel:
+			// Cancel is an explicit abort — do NOT enter drain state. Send
+			// CancelSession and return so the outer select tears the bridge
+			// down immediately.
+			_ = b.sendUpstream(v3Frame{
+				msgType:   v3MsgTypeFullClient,
+				flags:     v3FlagWithEvent,
+				serial:    v3SerialJSON,
+				event:     v3EventCancelSession,
+				sessionID: b.sessionID,
+				payload:   []byte(`{}`),
+			})
+
+			return nil
+
+		default:
+			b.sendClientError("unknown_event", string(event.Event))
+		}
+	}
+}
+
+func (b *v3Bridge) finishSession() error {
+	return b.sendUpstream(v3Frame{
+		msgType:   v3MsgTypeFullClient,
+		flags:     v3FlagWithEvent,
+		serial:    v3SerialJSON,
+		event:     v3EventFinishSession,
+		sessionID: b.sessionID,
+		payload:   []byte(`{}`),
+	})
+}
+
+func decodeJSONObject(data []byte) map[string]any {
+	if len(data) == 0 {
+		return nil
+	}
+
+	var out map[string]any
+
+	err := json.Unmarshal(data, &out)
+	if err != nil {
+		return nil
+	}
+
+	return out
+}

--- a/pkg/backend/volcengine/speech_stream_integration_test.go
+++ b/pkg/backend/volcengine/speech_stream_integration_test.go
@@ -1,0 +1,134 @@
+package volcengine_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moeru-ai/unspeech/pkg/backend"
+	"github.com/moeru-ai/unspeech/pkg/ho"
+)
+
+// TestBidirectionalStream_Integration is gated on VOLCENGINE_API_KEY and
+// VOLCENGINE_VOICE. Without both, the test is skipped — it makes a real call
+// to openspeech.bytedance.com and bills the project.
+//
+// Run with:
+//
+//	VOLCENGINE_API_KEY=sk-... VOLCENGINE_VOICE=zh_female_shuangkuaisisi_moon_bigtts \
+//	  go test -tags=integration -run TestBidirectionalStream_Integration ./pkg/backend/volcengine/...
+func TestBidirectionalStream_Integration(t *testing.T) {
+	apiKey := os.Getenv("VOLCENGINE_API_KEY")
+	voice := os.Getenv("VOLCENGINE_VOICE")
+
+	if apiKey == "" || voice == "" {
+		t.Skip("VOLCENGINE_API_KEY and VOLCENGINE_VOICE must be set")
+	}
+
+	resourceID := os.Getenv("VOLCENGINE_RESOURCE_ID")
+	if resourceID == "" {
+		resourceID = "seed-tts-2.0"
+	}
+
+	e := echo.New()
+	e.GET("/v1/audio/speech/stream", ho.MonadEcho1(backend.SpeechStream))
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	wsURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	wsURL.Scheme = "ws"
+	wsURL.Path = "/v1/audio/speech/stream"
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+apiKey)
+
+	dialer := *websocket.DefaultDialer
+	dialer.HandshakeTimeout = 10 * time.Second
+
+	conn, resp, err := dialer.Dial(wsURL.String(), hdr)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	require.NoError(t, err)
+
+	defer func() { _ = conn.Close() }()
+
+	startMsg := map[string]any{
+		"event":           "start",
+		"model":           "volcengine/seed-tts-2.0",
+		"voice":           voice,
+		"response_format": "mp3",
+		"extra_body": map[string]any{
+			"api_resource_id": resourceID,
+			"audio": map[string]any{
+				"sample_rate": 24000,
+				"bit_rate":    160000,
+			},
+		},
+	}
+
+	require.NoError(t, conn.WriteJSON(startMsg))
+	require.NoError(t, conn.WriteJSON(map[string]any{"event": "text", "text": "unspeech bidirectional streaming smoke test."}))
+	require.NoError(t, conn.WriteJSON(map[string]any{"event": "finish"}))
+
+	deadline := time.Now().Add(30 * time.Second)
+	require.NoError(t, conn.SetReadDeadline(deadline))
+
+	var (
+		sawSessionStarted  bool
+		sawSessionFinished bool
+		audioBytes         int
+	)
+
+	for !sawSessionFinished {
+		msgType, data, readErr := conn.ReadMessage()
+		if readErr != nil {
+			if websocket.IsCloseError(readErr, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				break
+			}
+
+			t.Fatalf("read message: %v (saw_started=%v audio_bytes=%d)", readErr, sawSessionStarted, audioBytes)
+		}
+
+		switch msgType {
+		case websocket.BinaryMessage:
+			audioBytes += len(data)
+
+		case websocket.TextMessage:
+			var event struct {
+				Event   string `json:"event"`
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			}
+
+			require.NoError(t, json.Unmarshal(data, &event))
+			t.Logf("event: %s", strings.TrimSpace(string(data)))
+
+			switch event.Event {
+			case "session.started":
+				sawSessionStarted = true
+			case "session.finished":
+				sawSessionFinished = true
+			case "error":
+				t.Fatalf("server error: code=%s message=%s", event.Code, event.Message)
+			}
+		}
+	}
+
+	require.True(t, sawSessionStarted, "expected session.started")
+	require.True(t, sawSessionFinished, "expected session.finished")
+	require.Positive(t, audioBytes, "expected at least one audio byte")
+}

--- a/pkg/backend/volcengine/speech_stream_mock_test.go
+++ b/pkg/backend/volcengine/speech_stream_mock_test.go
@@ -1,0 +1,523 @@
+package volcengine
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moeru-ai/unspeech/pkg/backend/types"
+	"github.com/moeru-ai/unspeech/pkg/ho"
+)
+
+// mockUpstream stubs the Volcengine v3 bidirectional TTS server so the
+// bridge can be driven end-to-end without real credentials. It speaks the
+// minimal subset of the v3 protocol the bridge actually uses.
+//
+// The hooks let each test customise post-TaskRequest behavior — e.g. one
+// scenario sends a few audio frames then SessionFinished, another stalls
+// audio to give the test time to send `cancel` before the upstream is
+// "done".
+type mockUpstream struct {
+	t *testing.T
+
+	// onTaskRequest is invoked after a TaskRequest text frame arrives. It
+	// drives the response side of the protocol (audio + SessionFinished /
+	// SessionFailed / etc.). The implementation may block to let the test
+	// inject more client-side events.
+	onTaskRequest func(conn *websocket.Conn, sessionID string)
+
+	// canceled is set when a CancelSession upstream frame is observed; tests
+	// can read it via .CanceledOK() / .DidCancel().
+	mu       sync.Mutex
+	canceled bool
+	finished bool
+
+	server *httptest.Server
+}
+
+func (m *mockUpstream) URL() string {
+	return strings.Replace(m.server.URL, "http://", "ws://", 1)
+}
+
+func (m *mockUpstream) DidCancel() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.canceled
+}
+
+func (m *mockUpstream) DidFinish() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.finished
+}
+
+func (m *mockUpstream) Close() {
+	m.server.Close()
+}
+
+func newMockUpstream(t *testing.T, onTaskRequest func(conn *websocket.Conn, sessionID string)) *mockUpstream {
+	t.Helper()
+
+	m := &mockUpstream{t: t, onTaskRequest: onTaskRequest}
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("mock upstream upgrade: %v", err)
+
+			return
+		}
+
+		defer conn.Close()
+
+		// Drive the v3 protocol manually.
+		sessionID := ""
+
+		for {
+			_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+
+			msgType, data, readErr := conn.ReadMessage()
+			if readErr != nil {
+				return
+			}
+
+			if msgType != websocket.BinaryMessage {
+				continue
+			}
+
+			frame, decodeErr := decodeV3Frame(data)
+			if decodeErr != nil {
+				t.Errorf("mock upstream decode: %v", decodeErr)
+
+				return
+			}
+
+			switch frame.event {
+			case v3EventStartConnection:
+				// Reply ConnectionStarted with a synthetic connection id.
+				replyFrame := v3Frame{
+					msgType: v3MsgTypeFullClient | 0b1000, // server-response flag bit
+					flags:   v3FlagWithEvent,
+					serial:  v3SerialJSON,
+					event:   v3EventConnectionStarted,
+					payload: []byte(`{}`),
+					// Mock upstream uses a fixed connection id; decodeV3Frame
+					// reads it but does not retain it past handshake. The
+					// connection_id field in encodeV3Frame is keyed off
+					// hasConnectionID(event) which is true for
+					// ConnectionStarted/Failed/Finished — but our encoder
+					// looks at sessionID, not connectionID. Send no
+					// connection-id payload prefix and let the decoder treat
+					// the next 4 bytes as the connection-id size (0). See
+					// encodeV3Frame: we set sessionID to "" and the
+					// hasSessionID check is false for connection events, so
+					// the encoder skips the session_id field and we manually
+					// inject a zero-length connection id. We work around the
+					// public encoder by hand-building this frame.
+				}
+
+				// encodeV3Frame doesn't handle connection_id, so build the
+				// frame inline matching the wire layout (header + event +
+				// conn_id_size=0 + payload_size + payload).
+				bin := buildConnEventFrame(replyFrame.event, []byte(`{}`))
+				if writeErr := conn.WriteMessage(websocket.BinaryMessage, bin); writeErr != nil {
+					t.Errorf("mock upstream write: %v", writeErr)
+
+					return
+				}
+
+			case v3EventStartSession:
+				sessionID = frame.sessionID
+				replyBin := encodeV3Frame(v3Frame{
+					msgType:   v3MsgTypeFullClient | 0b1000,
+					flags:     v3FlagWithEvent,
+					serial:    v3SerialJSON,
+					event:     v3EventSessionStarted,
+					sessionID: sessionID,
+					payload:   []byte(`{}`),
+				})
+				if writeErr := conn.WriteMessage(websocket.BinaryMessage, replyBin); writeErr != nil {
+					t.Errorf("mock upstream write: %v", writeErr)
+
+					return
+				}
+
+			case v3EventTaskRequest:
+				if m.onTaskRequest != nil {
+					m.onTaskRequest(conn, sessionID)
+				}
+
+			case v3EventFinishSession:
+				m.mu.Lock()
+				m.finished = true
+				m.mu.Unlock()
+
+			case v3EventCancelSession:
+				m.mu.Lock()
+				m.canceled = true
+				m.mu.Unlock()
+
+				// Reply SessionCanceled then close.
+				replyBin := encodeV3Frame(v3Frame{
+					msgType:   v3MsgTypeFullClient | 0b1000,
+					flags:     v3FlagWithEvent,
+					serial:    v3SerialJSON,
+					event:     v3EventSessionCanceled,
+					sessionID: sessionID,
+					payload:   []byte(`{}`),
+				})
+				_ = conn.WriteMessage(websocket.BinaryMessage, replyBin)
+
+				return
+
+			case v3EventFinishConnection:
+				return
+			}
+		}
+	}
+
+	m.server = httptest.NewServer(http.HandlerFunc(handler))
+
+	return m
+}
+
+// buildConnEventFrame is a one-off helper for connection-level frames the
+// public encoder doesn't handle (it only emits session_id-bearing
+// frames). Returns the wire bytes for ConnectionStarted/Failed/Finished
+// with a zero-length connection id and the supplied payload.
+func buildConnEventFrame(event v3Event, payload []byte) []byte {
+	header := []byte{
+		(1 << 4) | 1, // version=1, header_size=1*4
+		(byte(v3MsgTypeFullClient|0b1000) << 4) | v3FlagWithEvent,
+		(v3SerialJSON << 4) | 0,
+		0,
+	}
+
+	buf := make([]byte, 0, len(header)+4+4+4+len(payload))
+	buf = append(buf, header...)
+
+	// event (int32 big-endian)
+	buf = append(buf, byte(event>>24), byte(event>>16), byte(event>>8), byte(event))
+
+	// connection_id size = 0
+	buf = append(buf, 0, 0, 0, 0)
+
+	// payload size + payload
+	pSize := uint32(len(payload)) //nolint:gosec
+	buf = append(buf, byte(pSize>>24), byte(pSize>>16), byte(pSize>>8), byte(pSize))
+	buf = append(buf, payload...)
+
+	return buf
+}
+
+// dialBridge fronts unspeech's SpeechStream route in an httptest server
+// and returns a client ws connection ready to send `start`.
+func dialBridge(t *testing.T, upstreamURL string) *websocket.Conn {
+	t.Helper()
+
+	prev := v3BidirectionEndpoint
+	v3BidirectionEndpoint = upstreamURL
+
+	t.Cleanup(func() { v3BidirectionEndpoint = prev })
+
+	e := echo.New()
+	e.HideBanner = true
+	// We need backend.SpeechStream wired but importing the public package
+	// here would be circular; the unspeech command wires it at startup, so
+	// for the in-package test we use the volcengine bridge directly via a
+	// thin echo handler that mimics what SpeechStream does post-upgrade.
+	e.GET("/stream", ho.MonadEcho1(testSpeechStreamRoute))
+
+	srv := httptest.NewServer(e)
+
+	t.Cleanup(srv.Close)
+
+	wsURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	wsURL.Scheme = "ws"
+	wsURL.Path = "/stream"
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer mock-api-key-for-test")
+
+	dialer := *websocket.DefaultDialer
+	dialer.HandshakeTimeout = 5 * time.Second
+	conn, resp, dialErr := dialer.Dial(wsURL.String(), hdr)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	require.NoError(t, dialErr)
+
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return conn
+}
+
+// readClientEvents drains ws frames until either session.finished, an
+// error event, or the conn closes. Returns observed events in order plus
+// a count of binary (audio) bytes.
+type clientEvent struct {
+	Event   string `json:"event"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func drainClient(t *testing.T, conn *websocket.Conn, deadline time.Time) (events []clientEvent, audioBytes int) {
+	t.Helper()
+
+	_ = conn.SetReadDeadline(deadline)
+
+	for {
+		msgType, data, err := conn.ReadMessage()
+		if err != nil {
+			var closeErr *websocket.CloseError
+			if errors.As(err, &closeErr) {
+				return events, audioBytes
+			}
+
+			return events, audioBytes
+		}
+
+		switch msgType {
+		case websocket.BinaryMessage:
+			audioBytes += len(data)
+		case websocket.TextMessage:
+			var ev clientEvent
+
+			if err := json.Unmarshal(data, &ev); err == nil {
+				events = append(events, ev)
+
+				if ev.Event == "session.finished" || ev.Event == "error" {
+					return events, audioBytes
+				}
+			}
+		}
+	}
+}
+
+// TestBridge_FinishWaitsForUpstreamCompletion regression-tests the
+// codex CRITICAL fix: `finish` from the client must NOT tear the bridge
+// down before upstream drains audio + SessionFinished. Pre-fix the
+// client received zero or a partial audio prefix then close 1006.
+func TestBridge_FinishWaitsForUpstreamCompletion(t *testing.T) {
+	const totalAudioBytes = 4096
+	chunks := 4
+	chunkSize := totalAudioBytes / chunks
+
+	upstream := newMockUpstream(t, func(conn *websocket.Conn, sessionID string) {
+		// Send N audio frames, then SessionFinished. The audio frames have
+		// staggered writes to simulate streaming over wall-clock time —
+		// if the bridge tears down on `finish` instead of waiting, only
+		// the first few chunks would be forwarded.
+		for i := 0; i < chunks; i++ {
+			frame := encodeV3Frame(v3Frame{
+				msgType:   v3MsgTypeFullClient | 0b1000, // server-response
+				flags:     v3FlagWithEvent,
+				serial:    0, // raw audio
+				event:     v3EventTTSResponse,
+				sessionID: sessionID,
+				payload:   make([]byte, chunkSize),
+			})
+			_ = conn.WriteMessage(websocket.BinaryMessage, frame)
+
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		usagePayload := `{"status_code":20000000,"message":"ok","usage":{"text_words":42}}`
+		finalFrame := encodeV3Frame(v3Frame{
+			msgType:   v3MsgTypeFullClient | 0b1000,
+			flags:     v3FlagWithEvent,
+			serial:    v3SerialJSON,
+			event:     v3EventSessionFinished,
+			sessionID: sessionID,
+			payload:   []byte(usagePayload),
+		})
+		_ = conn.WriteMessage(websocket.BinaryMessage, finalFrame)
+	})
+
+	defer upstream.Close()
+
+	conn := dialBridge(t, upstream.URL())
+
+	require.NoError(t, conn.WriteJSON(map[string]any{
+		"event":           "start",
+		"model":           "volcengine/seed-tts-2.0",
+		"voice":           "mock-voice",
+		"response_format": "mp3",
+	}))
+	require.NoError(t, conn.WriteJSON(map[string]any{"event": "text", "text": "hello"}))
+	require.NoError(t, conn.WriteJSON(map[string]any{"event": "finish"}))
+
+	events, audioBytes := drainClient(t, conn, time.Now().Add(5*time.Second))
+
+	require.NotEmpty(t, events, "expected at least one server event")
+
+	var sawStarted, sawFinished bool
+	for _, ev := range events {
+		switch ev.Event {
+		case "session.started":
+			sawStarted = true
+		case "session.finished":
+			sawFinished = true
+		case "error":
+			t.Fatalf("unexpected error event: code=%s message=%s", ev.Code, ev.Message)
+		}
+	}
+
+	require.True(t, sawStarted, "expected session.started before finish")
+	require.True(t, sawFinished, "expected session.finished — finish must wait for upstream completion")
+	require.GreaterOrEqual(t, audioBytes, totalAudioBytes,
+		"expected all %d audio bytes; got %d — `finish` likely truncated the upstream", totalAudioBytes, audioBytes)
+}
+
+// TestBridge_CancelAfterFinish regression-tests codex follow-up #2.
+// Stage.vue sends `finish` immediately after `text`, so user-initiated
+// aborts later in the session land as `cancel` in the post-finish drain
+// state. Pre-fix the drain state silently swallowed it.
+//
+// Wire ordering this test exercises:
+//
+//	client → bridge:    start
+//	client → bridge:    text("abortable")
+//	bridge → upstream:  TaskRequest
+//	client → bridge:    finish              ← bridge enters drain state
+//	bridge → upstream:  FinishSession
+//	client → bridge:    cancel              ← pre-fix: swallowed by drain
+//	bridge → upstream:  CancelSession        ← must reach upstream (the assertion)
+func TestBridge_CancelAfterFinish(t *testing.T) {
+	// Upstream signals TaskRequest receipt but does not stall (so the
+	// mock's read loop keeps draining subsequent FinishSession +
+	// CancelSession frames from the bridge). We don't actually need any
+	// audio for this test — we're only verifying that CancelSession
+	// reaches upstream.
+	taskReached := make(chan struct{})
+	upstream := newMockUpstream(t, func(_ *websocket.Conn, _ string) {
+		close(taskReached)
+	})
+
+	defer upstream.Close()
+
+	conn := dialBridge(t, upstream.URL())
+
+	require.NoError(t, conn.WriteJSON(map[string]any{
+		"event": "start", "model": "volcengine/seed-tts-2.0", "voice": "mock-voice",
+	}))
+	require.NoError(t, conn.WriteJSON(map[string]any{"event": "text", "text": "abortable"}))
+	require.NoError(t, conn.WriteJSON(map[string]any{"event": "finish"}))
+
+	// Wait for upstream to confirm it got the TaskRequest before issuing
+	// cancel, otherwise we race the bridge's startedCh handshake.
+	select {
+	case <-taskReached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("upstream never received TaskRequest")
+	}
+
+	// Now send cancel — this lands in the post-finish drain branch.
+	require.NoError(t, conn.WriteJSON(map[string]any{"event": "cancel"}))
+
+	// The bridge should forward CancelSession upstream. Poll up to 3s.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && !upstream.DidCancel() {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	require.True(t, upstream.DidCancel(),
+		"upstream did not receive CancelSession — `cancel` was swallowed in post-finish drain")
+}
+
+// TestBridge_ErrorEventOnMissingApiKey is a fast regression check that
+// post-upgrade auth failures surface as JSON `error` events rather than
+// HTTP 500 stack traces written into the hijacked socket (smoke test
+// finding from this session).
+func TestBridge_ErrorEventOnMissingApiKey(t *testing.T) {
+	// Mock upstream is never reached; bridge fails at auth-header read.
+	upstream := newMockUpstream(t, func(_ *websocket.Conn, _ string) {})
+	defer upstream.Close()
+
+	prev := v3BidirectionEndpoint
+	v3BidirectionEndpoint = upstream.URL()
+
+	t.Cleanup(func() { v3BidirectionEndpoint = prev })
+
+	e := echo.New()
+	e.HideBanner = true
+	e.GET("/stream", ho.MonadEcho1(testSpeechStreamRoute))
+
+	srv := httptest.NewServer(e)
+
+	defer srv.Close()
+
+	wsURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	wsURL.Scheme = "ws"
+	wsURL.Path = "/stream"
+
+	dialer := *websocket.DefaultDialer
+	dialer.HandshakeTimeout = 5 * time.Second
+	// NO Authorization header — should produce a `missing_api_key` event.
+	conn, resp, dialErr := dialer.Dial(wsURL.String(), nil)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	require.NoError(t, dialErr)
+
+	defer func() { _ = conn.Close() }()
+
+	require.NoError(t, conn.WriteJSON(map[string]any{
+		"event": "start", "model": "volcengine/seed-tts-2.0", "voice": "mock-voice",
+	}))
+
+	events, _ := drainClient(t, conn, time.Now().Add(2*time.Second))
+
+	require.NotEmpty(t, events)
+	require.Equal(t, "error", events[0].Event)
+	require.Equal(t, "missing_api_key", events[0].Code)
+}
+
+// testSpeechStreamRoute is the in-package entry point for the tests.
+// It mirrors what `backend.SpeechStream` does post-upgrade, but lives
+// inside `package volcengine` so it can swap v3BidirectionEndpoint
+// without import cycles (backend imports volcengine; volcengine cannot
+// import backend).
+func testSpeechStreamRoute(c echo.Context) mo.Result[any] {
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+	ws, err := upgrader.Upgrade(c.Response(), c.Request(), nil)
+	if err != nil {
+		return mo.Ok[any](nil)
+	}
+
+	defer func() { _ = ws.Close() }()
+
+	_, payload, err := ws.ReadMessage()
+	if err != nil {
+		return mo.Ok[any](nil)
+	}
+
+	opts := types.NewSpeechStreamStartOptions(payload)
+	if opts.IsError() {
+		return mo.Ok[any](nil)
+	}
+
+	HandleSpeechStream(c, ws, mo.Some(opts.MustGet()))
+
+	return mo.Ok[any](nil)
+}

--- a/pkg/backend/volcengine/v3frame.go
+++ b/pkg/backend/volcengine/v3frame.go
@@ -1,0 +1,204 @@
+package volcengine
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// Volcengine V3 bidirectional TTS binary protocol.
+// https://www.volcengine.com/docs/6561/1329505
+
+type v3Event int32
+
+const (
+	v3EventStartConnection    v3Event = 1
+	v3EventFinishConnection   v3Event = 2
+	v3EventConnectionStarted  v3Event = 50
+	v3EventConnectionFailed   v3Event = 51
+	v3EventConnectionFinished v3Event = 52
+
+	v3EventStartSession    v3Event = 100
+	v3EventCancelSession   v3Event = 101
+	v3EventFinishSession   v3Event = 102
+	v3EventSessionStarted  v3Event = 150
+	v3EventSessionCanceled v3Event = 151
+	v3EventSessionFinished v3Event = 152
+	v3EventSessionFailed   v3Event = 153
+
+	v3EventTaskRequest      v3Event = 200
+	v3EventTTSSentenceStart v3Event = 350
+	v3EventTTSSentenceEnd   v3Event = 351
+	v3EventTTSResponse      v3Event = 352
+)
+
+const (
+	v3MsgTypeFullClient = 0b0001
+	v3MsgTypeError      = 0b1111
+
+	v3FlagWithEvent = 0b0100
+
+	v3SerialJSON = 0b0001
+
+	// v3HeaderUnit is the multiplier used by the protocol's header-size field
+	// (bits 0–3 of byte 0 encode header size in 4-byte units).
+	v3HeaderUnit = 4
+	// v3HalfByteMask masks the lower 4 bits of a header byte.
+	v3HalfByteMask = 0x0f
+	// v3MinHeaderSize is the protocol's minimum 4-byte header length.
+	v3MinHeaderSize = 4
+)
+
+type v3Frame struct {
+	msgType   byte
+	flags     byte
+	serial    byte
+	compress  byte
+	event     v3Event
+	sessionID string
+	errorCode uint32
+	payload   []byte
+}
+
+// hasSessionID reports whether the event carries a session_id field on the
+// wire. Connection-level events do not; session and data events do.
+func hasSessionID(e v3Event) bool {
+	switch e { //nolint:exhaustive
+	case v3EventStartSession, v3EventCancelSession, v3EventFinishSession,
+		v3EventSessionStarted, v3EventSessionCanceled, v3EventSessionFinished, v3EventSessionFailed,
+		v3EventTaskRequest, v3EventTTSSentenceStart, v3EventTTSSentenceEnd, v3EventTTSResponse:
+		return true
+	}
+
+	return false
+}
+
+// hasConnectionID reports whether the event carries a connection_id field on
+// the wire. Only ConnectionStarted/Failed/Finished do.
+func hasConnectionID(e v3Event) bool {
+	switch e { //nolint:exhaustive
+	case v3EventConnectionStarted, v3EventConnectionFailed, v3EventConnectionFinished:
+		return true
+	}
+
+	return false
+}
+
+func encodeV3Frame(f v3Frame) []byte {
+	// 4-byte header: version(1)<<4 | header_size(1), msgType<<4 | flags,
+	// serial<<4 | compress, reserved.
+	header := []byte{
+		(1 << v3HeaderUnit) | 1,
+		(f.msgType << v3HeaderUnit) | (f.flags & v3HalfByteMask),
+		(f.serial << v3HeaderUnit) | (f.compress & v3HalfByteMask),
+		0x00,
+	}
+
+	buf := make([]byte, 0, len(header)+8+len(f.sessionID)+len(f.payload))
+	buf = append(buf, header...)
+
+	if f.flags&v3FlagWithEvent != 0 {
+		buf = binary.BigEndian.AppendUint32(buf, uint32(f.event))
+	}
+
+	if hasSessionID(f.event) {
+		buf = binary.BigEndian.AppendUint32(buf, uint32(len(f.sessionID)))
+		buf = append(buf, f.sessionID...)
+	}
+
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(f.payload)))
+	buf = append(buf, f.payload...)
+
+	return buf
+}
+
+func decodeV3Frame(data []byte) (v3Frame, error) {
+	var f v3Frame
+	if len(data) < v3MinHeaderSize {
+		return f, errors.New("v3: frame too short")
+	}
+
+	f.msgType = data[1] >> v3HeaderUnit
+	f.flags = data[1] & v3HalfByteMask
+	f.serial = data[2] >> v3HeaderUnit
+	f.compress = data[2] & v3HalfByteMask
+
+	headerSize := max(int(data[0]&v3HalfByteMask)*v3HeaderUnit, v3MinHeaderSize)
+
+	p := headerSize
+
+	if f.msgType == v3MsgTypeError {
+		if len(data) < p+8 {
+			return f, errors.New("v3: error frame truncated")
+		}
+
+		f.errorCode = binary.BigEndian.Uint32(data[p : p+4])
+		p += 4
+
+		payloadSize := int(binary.BigEndian.Uint32(data[p : p+4]))
+		p += 4
+
+		if len(data) < p+payloadSize {
+			return f, errors.New("v3: error payload truncated")
+		}
+
+		f.payload = data[p : p+payloadSize]
+
+		return f, nil
+	}
+
+	if f.flags&v3FlagWithEvent != 0 {
+		if len(data) < p+4 {
+			return f, errors.New("v3: event field truncated")
+		}
+
+		f.event = v3Event(int32(binary.BigEndian.Uint32(data[p : p+4])))
+		p += 4
+	}
+
+	switch {
+	case hasSessionID(f.event):
+		if len(data) < p+4 {
+			return f, errors.New("v3: session id size truncated")
+		}
+
+		size := int(binary.BigEndian.Uint32(data[p : p+4]))
+		p += 4
+
+		if len(data) < p+size {
+			return f, errors.New("v3: session id truncated")
+		}
+
+		f.sessionID = string(data[p : p+size])
+		p += size
+	case hasConnectionID(f.event):
+		if len(data) < p+4 {
+			return f, errors.New("v3: connection id size truncated")
+		}
+
+		size := int(binary.BigEndian.Uint32(data[p : p+4]))
+		p += 4
+
+		if len(data) < p+size {
+			return f, errors.New("v3: connection id truncated")
+		}
+
+		// connection id is read but not retained — we don't need it after handshake.
+		p += size
+	}
+
+	if len(data) < p+4 {
+		return f, fmt.Errorf("v3: payload size truncated at event %d", f.event)
+	}
+
+	payloadSize := int(binary.BigEndian.Uint32(data[p : p+4]))
+	p += 4
+
+	if len(data) < p+payloadSize {
+		return f, fmt.Errorf("v3: payload truncated at event %d (want %d, got %d)", f.event, payloadSize, len(data)-p)
+	}
+
+	f.payload = data[p : p+payloadSize]
+
+	return f, nil
+}

--- a/pkg/backend/volcengine/v3frame_test.go
+++ b/pkg/backend/volcengine/v3frame_test.go
@@ -1,0 +1,77 @@
+package volcengine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestV3FrameRoundTrip_StartConnection(t *testing.T) {
+	in := v3Frame{
+		msgType: v3MsgTypeFullClient,
+		flags:   v3FlagWithEvent,
+		serial:  v3SerialJSON,
+		event:   v3EventStartConnection,
+		payload: []byte(`{}`),
+	}
+
+	out, err := decodeV3Frame(encodeV3Frame(in))
+	require.NoError(t, err)
+	require.Equal(t, in.event, out.event)
+	require.Equal(t, in.payload, out.payload)
+	require.Empty(t, out.sessionID)
+}
+
+func TestV3FrameRoundTrip_TaskRequest(t *testing.T) {
+	in := v3Frame{
+		msgType:   v3MsgTypeFullClient,
+		flags:     v3FlagWithEvent,
+		serial:    v3SerialJSON,
+		event:     v3EventTaskRequest,
+		sessionID: "session-abc",
+		payload:   []byte(`{"text":"hello"}`),
+	}
+
+	out, err := decodeV3Frame(encodeV3Frame(in))
+	require.NoError(t, err)
+	require.Equal(t, in.event, out.event)
+	require.Equal(t, in.sessionID, out.sessionID)
+	require.Equal(t, in.payload, out.payload)
+}
+
+func TestV3FrameRoundTrip_TTSResponseAudio(t *testing.T) {
+	// Audio-only response from the server carries the session id and raw bytes.
+	in := v3Frame{
+		msgType:   v3MsgTypeFullClient,
+		flags:     v3FlagWithEvent,
+		serial:    v3SerialJSON,
+		event:     v3EventTTSResponse,
+		sessionID: "sid",
+		payload:   []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+	}
+
+	out, err := decodeV3Frame(encodeV3Frame(in))
+	require.NoError(t, err)
+	require.Equal(t, in.event, out.event)
+	require.Equal(t, in.sessionID, out.sessionID)
+	require.Equal(t, in.payload, out.payload)
+}
+
+func TestDecodeV3Frame_RejectsShortInput(t *testing.T) {
+	_, err := decodeV3Frame([]byte{0x11})
+	require.Error(t, err)
+}
+
+func TestDecodeV3Frame_TruncatedPayload(t *testing.T) {
+	frame := encodeV3Frame(v3Frame{
+		msgType:   v3MsgTypeFullClient,
+		flags:     v3FlagWithEvent,
+		serial:    v3SerialJSON,
+		event:     v3EventTaskRequest,
+		sessionID: "sid",
+		payload:   []byte(`{"text":"hello"}`),
+	})
+
+	_, err := decodeV3Frame(frame[:len(frame)-3])
+	require.Error(t, err)
+}


### PR DESCRIPTION
- Implemented `TestBidirectionalStream_Integration` to test the real-time speech streaming functionality with Volcengine API, ensuring proper handling of audio data and session events.
- Created `mockUpstream` to simulate the Volcengine TTS server for unit testing, allowing for controlled testing of various scenarios without real API calls.
- Added `v3frame` package to handle encoding and decoding of the Volcengine V3 binary protocol, including frame structure and event types.
- Developed comprehensive tests for `v3Frame` encoding and decoding to ensure data integrity and error handling.