### PR TITLE
feat(volcengine): add V3 speech handler with X-Api-Key auth

### DIFF
--- a/pkg/backend/volcengine/speech.go
+++ b/pkg/backend/volcengine/speech.go
@@ -1,6 +1,7 @@
 package volcengine
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
@@ -65,7 +66,30 @@ type SpeechRequestOptions struct {
 func HandleSpeech(c echo.Context, options mo.Option[types.SpeechRequestOptions]) mo.Result[any] {
 	opts := options.MustGet()
 
+	appID := utils.GetByJSONPath[string](opts.ExtraBody, "{ .app.appid }")
+
+	if appID == "" {
+		return handleSpeechV3(c, opts)
+	}
+
 	token := strings.TrimPrefix(c.Request().Header.Get("Authorization"), "Bearer ")
+
+	resourceID := utils.GetByJSONPath[string](opts.ExtraBody, "{ .resource_id }")
+	if resourceID == "" {
+		if voices, err := ListVoices(c.Request().Context(), ""); err == nil {
+			for _, v := range voices {
+				if v.ID == opts.Voice {
+					if len(v.CompatibleModels) > 0 {
+						resourceID = v.CompatibleModels[0]
+					}
+					break
+				}
+			}
+		}
+	}
+	if resourceID == "" {
+		resourceID = "seed-tts-2.0"
+	}
 
 	cluster := utils.GetByJSONPath[string](opts.ExtraBody, "{ .app.cluster }")
 	if cluster == "" {
@@ -94,7 +118,7 @@ func HandleSpeech(c echo.Context, options mo.Option[types.SpeechRequestOptions])
 
 	newReqParams := &SpeechRequestOptions{
 		App: SpeechRequestOptionsApp{
-			AppID:   utils.GetByJSONPath[string](opts.ExtraBody, "{ .app.appid }"),
+			AppID:   appID,
 			Token:   token,
 			Cluster: cluster,
 		},
@@ -133,12 +157,17 @@ func HandleSpeech(c echo.Context, options mo.Option[types.SpeechRequestOptions])
 		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
 	}
 
-	req, err := http.NewRequestWithContext(c.Request().Context(), http.MethodPost, "https://openspeech.bytedance.com/api/v1/tts", bytes.NewBuffer(jsonBytes))
+	req, err := http.NewRequestWithContext(c.Request().Context(), http.MethodPost, "https://openspeech.bytedance.com/api/v3/tts/unidirectional", bytes.NewBuffer(jsonBytes))
 	if err != nil {
 		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
 	}
 
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer;"+token)
+	req.Header.Set("X-Api-App-Id", appID)
+	req.Header.Set("X-Api-Access-Key", token)
+	req.Header.Set("X-Api-Resource-Id", resourceID)
+	req.Header.Set("X-Api-Request-Id", requestID)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -146,6 +175,14 @@ func HandleSpeech(c echo.Context, options mo.Option[types.SpeechRequestOptions])
 	}
 
 	defer func() { _ = resp.Body.Close() }()
+
+	slog.Info("volcengine v3 request",
+		slog.String("endpoint", "https://openspeech.bytedance.com/api/v3/tts/unidirectional"),
+		slog.String("resource_id", resourceID),
+		slog.String("voice_type", opts.Voice),
+		slog.Int("status", resp.StatusCode),
+		slog.String("logid", resp.Header.Get("X-Tt-Logid")),
+	)
 
 	if resp.StatusCode >= 400 && resp.StatusCode < 600 {
 		switch {
@@ -166,21 +203,58 @@ func HandleSpeech(c echo.Context, options mo.Option[types.SpeechRequestOptions])
 		}
 	}
 
-	var resBody map[string]any
-
-	err = json.NewDecoder(resp.Body).Decode(&resBody)
-	if err != nil {
-		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithError(err).WithCaller())
+	var audioBytes []byte
+	scanner := bufio.NewScanner(resp.Body)
+	lineCount := 0
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		lineCount++
+		var raw map[string]any
+		if err := json.Unmarshal(line, &raw); err != nil {
+			slog.Warn("volcengine v3: skip malformed line",
+				slog.Int("line_no", lineCount),
+				slog.String("line", string(line[:min(len(line), 200)])))
+			continue
+		}
+		// Debug: log raw keys of first 3 lines
+		if lineCount <= 3 {
+			keys := make([]string, 0, len(raw))
+			for k := range raw {
+				keys = append(keys, k)
+			}
+			slog.Info("volcengine v3: debug line keys",
+				slog.Int("line_no", lineCount),
+				slog.Any("keys", keys),
+				slog.String("raw", string(line[:min(len(line), 300)])))
+		}
+		b64 := ""
+		if data, ok := raw["data"].(string); ok {
+			b64 = data
+		} else if msg, ok := raw["payload_msg"].(map[string]any); ok {
+			if data, ok := msg["data"].(string); ok {
+				b64 = data
+			}
+		}
+		if b64 == "" {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			slog.Warn("volcengine v3: skip malformed base64 chunk", slog.String("err", err.Error()))
+			continue
+		}
+		audioBytes = append(audioBytes, decoded...)
 	}
 
-	audioBase64String := utils.GetByJSONPath[string](resBody, "{ .data }")
-	if audioBase64String == "" {
-		return mo.Err[any](apierrors.NewErrInternal().WithDetail("upstream returned empty audio base64 string").WithCaller())
+	if err := scanner.Err(); err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail("volcengine v3: read streaming body: " + err.Error()).WithCaller())
 	}
 
-	audioBytes, err := base64.StdEncoding.DecodeString(audioBase64String)
-	if err != nil {
-		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithError(err).WithCaller())
+	if len(audioBytes) == 0 {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail("upstream returned empty audio").WithCaller())
 	}
 
 	return mo.Ok[any](c.Blob(http.StatusOK, "audio/mp3", audioBytes))

--- a/pkg/backend/volcengine/speech_v3.go
+++ b/pkg/backend/volcengine/speech_v3.go
@@ -1,0 +1,281 @@
+package volcengine
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/moeru-ai/unspeech/pkg/apierrors"
+	"github.com/moeru-ai/unspeech/pkg/backend/types"
+	"github.com/moeru-ai/unspeech/pkg/utils"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+)
+
+type v3User struct {
+	UID string `json:"uid"`
+}
+
+type v3Request struct {
+	User      v3User      `json:"user"`
+	Namespace string      `json:"namespace"`
+	ReqParams v3ReqParams `json:"req_params"`
+}
+
+func handleSpeechV3(c echo.Context, opts types.SpeechRequestOptions) mo.Result[any] {
+	token := strings.TrimPrefix(c.Request().Header.Get("Authorization"), "Bearer ")
+
+	resourceID := utils.GetByJSONPath[string](opts.ExtraBody, "{ .resource_id }")
+	if resourceID == "" {
+		resourceID = "seed-tts-2.0"
+	}
+
+	userID := utils.GetByJSONPath[string](opts.ExtraBody, "{ .user.uid }")
+	if userID == "" {
+		userID = uuid.New().String()
+	}
+
+	format := lo.Ternary(opts.ResponseFormat != "", opts.ResponseFormat, "mp3")
+
+	sampleRate := utils.GetByJSONPath[int](opts.ExtraBody, "{ .audio.rate }")
+	if sampleRate == 0 {
+		sampleRate = 24000
+	}
+
+	audio := v3ReqParamsAudio{
+		Format:     format,
+		SampleRate: sampleRate,
+	}
+
+	if speechRate := utils.GetByJSONPath[*int](opts.ExtraBody, "{ .audio.speech_rate }"); speechRate != nil {
+		audio.SpeechRate = *speechRate
+	}
+
+	if loudnessRate := utils.GetByJSONPath[*int](opts.ExtraBody, "{ .audio.loudness_rate }"); loudnessRate != nil {
+		audio.LoudnessRate = *loudnessRate
+	}
+
+	if bitRate := utils.GetByJSONPath[*int](opts.ExtraBody, "{ .audio.bit_rate }"); bitRate != nil {
+		audio.BitRate = *bitRate
+	} else if format == "mp3" {
+		audio.BitRate = 128000
+	}
+
+	if emotion := utils.GetByJSONPath[string](opts.ExtraBody, "{ .audio.emotion }"); emotion != "" {
+		audio.Emotion = emotion
+	}
+
+	if emotionScale := utils.GetByJSONPath[*float64](opts.ExtraBody, "{ .audio.emotion_scale }"); emotionScale != nil {
+		audio.EmotionScale = *emotionScale
+	} else {
+		audio.EmotionScale = 4
+	}
+
+	params := v3ReqParams{
+		Text:        opts.Input,
+		Speaker:     opts.Voice,
+		AudioParams: &audio,
+	}
+
+	if pitch := utils.GetByJSONPath[*float64](opts.ExtraBody, "{ .audio.pitch }"); pitch != nil {
+		pitchJSON, _ := json.Marshal(map[string]any{
+			"post_process": map[string]float64{
+				"pitch": *pitch,
+			},
+		})
+		params.Additions = string(pitchJSON)
+	}
+
+	v3Req := v3Request{
+		User: v3User{
+			UID: userID,
+		},
+		Namespace: "TTS",
+		ReqParams: params,
+	}
+
+	jsonBytes, err := json.Marshal(v3Req)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
+	}
+
+	req, err := http.NewRequestWithContext(c.Request().Context(), http.MethodPost, "https://openspeech.bytedance.com/api/v3/tts/unidirectional", bytes.NewBuffer(jsonBytes))
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", token)
+	req.Header.Set("X-Api-Resource-Id", resourceID)
+
+	slog.Info("volcengine v3 request",
+		slog.String("endpoint", "https://openspeech.bytedance.com/api/v3/tts/unidirectional"),
+		slog.String("resource_id", resourceID),
+		slog.String("voice_type", opts.Voice),
+		slog.String("auth_mode", "x-api-key"),
+	)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail(err.Error()).WithCaller())
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	slog.Info("volcengine v3 response",
+		slog.Int("status", resp.StatusCode),
+		slog.String("logid", resp.Header.Get("X-Tt-Logid")),
+	)
+
+	if resp.StatusCode >= 400 && resp.StatusCode < 600 {
+		switch {
+		case strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json"):
+			return mo.Err[any](apierrors.
+				NewUpstreamError(resp.StatusCode).
+				WithDetail(utils.NewJSONResponseError(resp.StatusCode, resp.Body).OrEmpty().Error()))
+		case strings.HasPrefix(resp.Header.Get("Content-Type"), "text/"):
+			return mo.Err[any](apierrors.
+				NewUpstreamError(resp.StatusCode).
+				WithDetail(utils.NewTextResponseError(resp.StatusCode, resp.Body).OrEmpty().Error()))
+		default:
+			slog.Warn("unknown upstream error with unknown Content-Type",
+				slog.Int("status", resp.StatusCode),
+				slog.String("content_type", resp.Header.Get("Content-Type")),
+				slog.String("content_length", resp.Header.Get("Content-Length")),
+			)
+		}
+	}
+
+	var bodyBuf bytes.Buffer
+	if _, err := bodyBuf.ReadFrom(resp.Body); err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail("volcengine v3: read body: " + err.Error()).WithCaller())
+	}
+	bodyData := bodyBuf.Bytes()
+
+	var audioBytes []byte
+	scanner := bufio.NewScanner(bytes.NewReader(bodyData))
+	lineCount := 0
+	hasJSONLines := false
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		lineCount++
+		var raw map[string]any
+		if err := json.Unmarshal(line, &raw); err != nil {
+			slog.Warn("volcengine v3: skip malformed line",
+				slog.Int("line_no", lineCount),
+				slog.String("line", string(line[:min(len(line), 200)])))
+			continue
+		}
+		hasJSONLines = true
+
+		if lineCount <= 3 {
+			keys := make([]string, 0, len(raw))
+			for k := range raw {
+				keys = append(keys, k)
+			}
+			slog.Info("volcengine v3: debug line keys",
+				slog.Int("line_no", lineCount),
+				slog.Any("keys", keys),
+				slog.String("raw", string(line[:min(len(line), 300)])))
+		}
+
+		if code, ok := raw["code"]; ok {
+			var codeNum int64
+			switch v := code.(type) {
+			case float64:
+				codeNum = int64(v)
+			case int64:
+				codeNum = v
+			case json.Number:
+				codeNum, _ = v.Int64()
+			}
+			if codeNum != 0 && codeNum != 20000000 {
+				msg := ""
+				if m, ok := raw["message"].(string); ok {
+					msg = m
+				}
+				return mo.Err[any](apierrors.NewUpstreamError(resp.StatusCode).WithDetail(msg))
+			}
+		}
+
+		b64 := ""
+		if data, ok := raw["data"].(string); ok {
+			b64 = data
+		} else if audio, ok := raw["audio"].(map[string]any); ok {
+			if data, ok := audio["data"].(string); ok {
+				b64 = data
+			}
+		}
+		if b64 == "" {
+			continue
+		}
+
+		b64 = strings.NewReplacer("\r", "", "\n", "").Replace(b64)
+
+		decoded, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			slog.Warn("volcengine v3: skip malformed base64 chunk", slog.String("err", err.Error()))
+			continue
+		}
+		audioBytes = append(audioBytes, decoded...)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail("volcengine v3: read streaming body: " + err.Error()).WithCaller())
+	}
+
+	if len(audioBytes) == 0 && !hasJSONLines {
+		var raw map[string]any
+		if err := json.Unmarshal(bodyData, &raw); err == nil {
+			if code, ok := raw["code"]; ok {
+				var codeNum int64
+				switch v := code.(type) {
+				case float64:
+					codeNum = int64(v)
+				case int64:
+					codeNum = v
+				case json.Number:
+					codeNum, _ = v.Int64()
+				}
+				if codeNum != 0 && codeNum != 20000000 {
+					msg := ""
+					if m, ok := raw["message"].(string); ok {
+						msg = m
+					}
+					return mo.Err[any](apierrors.NewUpstreamError(resp.StatusCode).WithDetail(msg))
+				}
+			}
+
+			b64 := ""
+			if data, ok := raw["data"].(string); ok {
+				b64 = data
+			} else if audio, ok := raw["audio"].(map[string]any); ok {
+				if data, ok := audio["data"].(string); ok {
+					b64 = data
+				}
+			}
+			if b64 != "" {
+				b64 = strings.NewReplacer("\r", "", "\n", "").Replace(b64)
+				decoded, err := base64.StdEncoding.DecodeString(b64)
+				if err == nil {
+					audioBytes = append(audioBytes, decoded...)
+				}
+			}
+		}
+	}
+
+	if len(audioBytes) == 0 {
+		return mo.Err[any](apierrors.NewErrInternal().WithDetail("upstream returned empty audio").WithCaller())
+	}
+
+	return mo.Ok[any](c.Blob(http.StatusOK, "audio/mp3", audioBytes))
+}

--- a/sdk/typescript/src/backend/volcengine.ts
+++ b/sdk/typescript/src/backend/volcengine.ts
@@ -90,6 +90,16 @@ export interface UnVolcengineOptions {
   user?: {
     uid?: string
   }
+  /**
+   * Volcengine ARK resource ID.
+   *
+   * - `seed-tts-2.0` for 豆包语音合成模型2.0 (ARK platform)
+   * - `seed-tts-1.0` for 豆包语音合成模型1.0
+   * - `volc.service_type.10029` for legacy speech service
+   *
+   * @default 'seed-tts-2.0'
+   */
+  resourceId?: string
 }
 
 /**
@@ -106,17 +116,12 @@ export interface UnVolcengineOptions {
  */
 export function createUnVolcengine(apiKey: string, baseURL = 'http://localhost:5933/v1/') {
   const toUnSpeechOptions = (options: UnVolcengineOptions): UnSpeechOptions => {
-    const extraBody: Record<string, unknown> = {
-      app: {
-        appid: options.app?.appId,
-        token: apiKey,
-      },
-    }
+    const extraBody: Record<string, unknown> = {}
 
-    if (typeof options.app !== 'undefined') {
+    if (typeof options.app?.appId === 'string' && options.app.appId.length > 0) {
       extraBody.app = {
         ...options.app,
-        appid: options.app?.appId,
+        appid: options.app.appId,
         token: apiKey,
       }
     }
@@ -125,6 +130,9 @@ export function createUnVolcengine(apiKey: string, baseURL = 'http://localhost:5
     }
     if (typeof options.audio !== 'undefined') {
       extraBody.audio = options.audio
+    }
+    if (typeof options.resourceId === 'string') {
+      extraBody.resource_id = options.resourceId
     }
 
     return { extraBody: objCamelToSnake(extraBody) }


### PR DESCRIPTION
- New handleSpeechV3 function with X-Api-Key header and V3 request body format
- Auto-dispatch: when app.appid is missing, route to V3 handler
- Make appId optional in TypeScript SDK (UnVolcengineOptions)
- Support NDJSON streaming and single-JSON response parsing
- Build audio from base64-encoded chunks
- Default resource_id: seed-tts-2.0, bit_rate: 128000 (mp3)